### PR TITLE
Fix a bug where some nested headers would get appended to the incorrect ...

### DIFF
--- a/js/core/markdown.js
+++ b/js/core/markdown.js
@@ -87,6 +87,7 @@ define(
               section.appendChild(header);
               findParent(position).appendChild(section);
               stack[position] = section;
+              stack.length = position + 1;
               current = section;
             }
 

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -105,6 +105,20 @@ describe("Core - Markdown", function () {
         });
     });
 
+    it("should gracefully handle jumps in nested headers", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig,
+                        body: '\nFoo\n===\n\nBar\n---\n\nBaz\n===\n\n### Foobar ###\n\n'
+                    }, function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+
+        runs(function () {
+            expect($('#baz > #foobar', doc).length).toEqual(1);
+        });
+    });
+
     it("should nest sections according to their first header, if present", function () {
         var doc;
         runs(function () {


### PR DESCRIPTION
...section (e.g.: an H4 right after an H2 could be appended to an H3 further up in the content).
