### PR TITLE
Update js/w3c/headers.js

### DIFF
--- a/js/w3c/headers.js
+++ b/js/w3c/headers.js
@@ -149,7 +149,7 @@ define(
             ,   PER:            "Proposed Edited Recommendation"
             ,   REC:            "Recommendation"
             ,   RSCND:          "Rescinded Recommendation"
-            ,   unofficial:     "Unofficial Draft"
+            ,   unofficial:     "Draft"
             ,   base:           "Document"
             ,   finding:        "TAG Finding"
             ,   "draft-finding": "Draft TAG Finding"


### PR DESCRIPTION
When using ReSpec outside of W3C, the word "unofficial" in the heading is undesirable.
I plan to submit a feature request for a more generic template for use outside W3C, but meanwhile would be at least useful to remove the word "Unofficial" from the heading.
This shouldn't hurt any existing user while remove a limitation for others.

The "unofficial" CSS template also have have a "unofficial draft" logo, but that is easy to workaround in CSS in the document itself.
