### PR TITLE
support for WebIDL "serializer" syntax

### DIFF
--- a/js/core/templates/webidl/serializer.html
+++ b/js/core/templates/webidl/serializer.html
@@ -1,3 +1,2 @@
 <span class='idlSerializer'>{{extAttr obj indent true
-}}{{idn indent}} serializer {{pads pad
-}}{{#if values}} = <span class='idlSerializerValues'>{{values}}</span>{{/if}};</span>
+}}{{idn indent}}serializer{{#if values}} = <span class='idlSerializerValues'>{{values}}</span>{{/if}};</span>

--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -23,13 +23,14 @@ define(
     ,   "tmpl!core/templates/webidl/callback.html"
     ,   "tmpl!core/templates/webidl/method.html"
     ,   "tmpl!core/templates/webidl/attribute.html"
+    ,   "tmpl!core/templates/webidl/serializer.html"
     ,   "tmpl!core/templates/webidl/field.html"
     ,   "tmpl!core/templates/webidl/exception.html"
     ,   "tmpl!core/templates/webidl/interface.html"
     ],
     function (hb, css, idlModuleTmpl, idlTypedefTmpl, idlImplementsTmpl, idlDictMemberTmpl, idlDictionaryTmpl,
                    idlEnumItemTmpl, idlEnumTmpl, idlConstTmpl, idlParamTmpl, idlCallbackTmpl, idlMethodTmpl,
-                   idlAttributeTmpl, idlFieldTmpl, idlExceptionTmpl, idlInterfaceTmpl) {
+              idlAttributeTmpl, idlSerializerTmpl, idlFieldTmpl, idlExceptionTmpl, idlInterfaceTmpl) {
         var WebIDLProcessor = function (cfg) {
                 this.parent = { type: "module", id: "outermost", children: [] };
                 if (!cfg) cfg = {};
@@ -527,6 +528,7 @@ define(
                 if (match) {
                     obj.type = "serializer";
 		    obj.values = [];
+                    this.setID(obj, "serializer");
 		    var serializermap = match[3],
 		    serializerlist = match[6],
 		    serializerattribute = match[9], rawvalues;
@@ -534,13 +536,16 @@ define(
 		    if (serializermap) {
 			obj.serializertype = "map";
 			rawvalues = match[4];
-		    } else if (serializerlist) {
+		    } 
+		    else if (serializerlist) {
 			obj.serializertype = "list";
 			rawvalues = match[7];
-		    } else if (serializerattribute) {
+		    }
+		    else if (serializerattribute) {
 			obj.serializertype = "attribute";
 			obj.values.push(serializerattribute);
-		    } else {
+		    }
+		    else {
 			obj.serializertype = "prose";
 		    }
 		    if (rawvalues) {
@@ -551,16 +556,19 @@ define(
 			obj.all = false;
 			if (values[0] == "getter") {
 			    obj.getter = true;
-			} else {
-			    if (values[0] == "inherit") {
-				obj.inherit = true;
-				values.shift();
+			} 
+			else {
+			    if (obj.serializertype == "map") {
+ 				if (values[0] == "inherit") {
+				    obj.inherit = true;
+				    values.shift();
+				}
+				if (values[0] == "attribute" && obj.serializertype == "map" ) {
+				    obj.all = true;
+				    values = [];
+				}
 			    }
-			    if (values[0] == "attribute" && obj.serializertype == "map" ) {
-				obj.all = true;
-			    } else {
-				obj.values = values;
-			    }
+			    obj.values = values;
 			}
 		    }
 		    return obj;
@@ -841,136 +849,182 @@ define(
                         var secTitle = type;
                         secTitle = secTitle.substr(0, 1).toUpperCase() + secTitle.substr(1) + (type != "serializer" ? "s" : "");
                         if (!this.conf.noIDLSectionTitle) sn.element("h2", {}, sec, secTitle);
-                        var dl = sn.element("dl", { "class": type + "s" }, sec);
-                        for (var j = 0; j < things.length; j++) {
-                            var it = things[j];
-                            var id = (type == "method") ? this.makeMethodID(curLnk, it) : sn.idThatDoesNotExist(curLnk + it.refId);
-                            var dt = sn.element("dt", { id: id }, dl);
-                            sn.element("code", {}, dt, it.id);
-                            if (it.isStatic) dt.appendChild(this.doc.createTextNode(", static"));
-                            var desc = sn.element("dd", {}, dl, [it.description]);
-                            if (type == "method") {
-                                if (it.params.length) {
-                                    var table = sn.element("table", { "class": "parameters" }, desc);
-                                    var tr = sn.element("tr", {}, table);
-                                    ["Parameter", "Type", "Nullable", "Optional", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                    for (var k = 0; k < it.params.length; k++) {
-                                        var prm = it.params[k];
-                                        var tr = sn.element("tr", {}, table);
-                                        sn.element("td", { "class": "prmName" }, tr, prm.id);
-                                        var tyTD = sn.element("td", { "class": "prmType" }, tr);
-                                        var code = sn.element("code", {}, tyTD);
-                                        code.innerHTML = datatype(prm.datatype);
-                                        if (prm.array) code.innerHTML += arrsq(prm);
-                                        if (prm.defaultValue) {
-                                            code.innerHTML += " = " + prm.defaultValue;
-                                        }
-                                        if (prm.nullable) sn.element("td", { "class": "prmNullTrue" }, tr, "\u2714");
-                                        else              sn.element("td", { "class": "prmNullFalse" }, tr, "\u2718");
-                                        if (prm.optional) sn.element("td", { "class": "prmOptTrue" }, tr, "\u2714");
-                                        else              sn.element("td", { "class": "prmOptFalse" }, tr, "\u2718");
-                                        var cnt = prm.description ? [prm.description] : "";
-                                        sn.element("td", { "class": "prmDesc" }, tr, cnt);
-                                    }
-                                }
-                                else {
-                                    sn.element("div", {}, desc, [sn.element("em", {}, null, "No parameters.")]);
-                                }
-                                if (this.conf.idlOldStyleExceptions && it.raises.length) {
-                                    var table = sn.element("table", { "class": "exceptions" }, desc);
-                                    var tr = sn.element("tr", {}, table);
-                                    ["Exception", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                    for (var k = 0; k < it.raises.length; k++) {
-                                        var exc = it.raises[k];
-                                        var tr = sn.element("tr", {}, table);
-                                        sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
-                                        var dtd = sn.element("td", { "class": "excDesc" }, tr);
-                                        if (exc.type == "simple") {
-                                            $(dtd).append(exc.description);
-                                        }
-                                        else {
-                                            var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
-                                            for (var m = 0; m < exc.description.length; m++) {
-                                                var cd = exc.description[m];
-                                                var tr = sn.element("tr", {}, ctab);
-                                                sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
-                                                sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+			if (type != "serializer") {
+                            var dl = sn.element("dl", { "class": type + "s" }, sec);
+                            for (var j = 0; j < things.length; j++) {
+				var it = things[j];
+				var id = (type == "method") ? this.makeMethodID(curLnk, it) : sn.idThatDoesNotExist(curLnk + it.refId);
+				var dt = sn.element("dt", { id: id }, dl);
+				sn.element("code", {}, dt, it.id);
+				if (it.isStatic) dt.appendChild(this.doc.createTextNode(", static"));
+				var desc = sn.element("dd", {}, dl, [it.description]);
+				if (type == "method") {
+                                    if (it.params.length) {
+					var table = sn.element("table", { "class": "parameters" }, desc);
+					var tr = sn.element("tr", {}, table);
+					["Parameter", "Type", "Nullable", "Optional", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+					for (var k = 0; k < it.params.length; k++) {
+                                            var prm = it.params[k];
+                                            var tr = sn.element("tr", {}, table);
+                                            sn.element("td", { "class": "prmName" }, tr, prm.id);
+                                            var tyTD = sn.element("td", { "class": "prmType" }, tr);
+                                            var code = sn.element("code", {}, tyTD);
+                                            code.innerHTML = datatype(prm.datatype);
+                                            if (prm.array) code.innerHTML += arrsq(prm);
+                                            if (prm.defaultValue) {
+						code.innerHTML += " = " + prm.defaultValue;
                                             }
-                                        }
+                                            if (prm.nullable) sn.element("td", { "class": "prmNullTrue" }, tr, "\u2714");
+                                            else              sn.element("td", { "class": "prmNullFalse" }, tr, "\u2718");
+                                            if (prm.optional) sn.element("td", { "class": "prmOptTrue" }, tr, "\u2714");
+                                            else              sn.element("td", { "class": "prmOptFalse" }, tr, "\u2718");
+                                            var cnt = prm.description ? [prm.description] : "";
+                                            sn.element("td", { "class": "prmDesc" }, tr, cnt);
+					}
                                     }
-                                }
-                                // else {
-                                //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
-                                // }
-
-                                var reDiv = sn.element("div", {}, desc);
-                                sn.element("em", {}, reDiv, "Return type: ");
-
-                                var code = sn.element("code", {}, reDiv);
-                                code.innerHTML = datatype(it.datatype);
-                                if (it.array) code.innerHTML += arrsq(it);
-                                if (it.nullable) sn.text(", nullable", reDiv);
-                            }
-                            else if (type == "attribute") {
-                                sn.text(" of type ", dt);
-                                if (it.array) {
-                                    for (var m = 0, n = it.arrayCount; m < n; m++) sn.text("array of ", dt);
-                                }
-                                var span = sn.element("span", { "class": "idlAttrType" }, dt);
-                                var matched = /^sequence<(.+)>$/.exec(it.datatype);
-                                if (matched) {
-                                    sn.text("sequence<", span);
-                                    sn.element("a", {}, span, matched[1]);
-                                    sn.text(">", span);
-                                }
-                                else {
-                                    sn.element("a", {}, span, it.datatype);
-                                }
-                                if (it.readonly) sn.text(", readonly", dt);
-                                if (it.nullable) sn.text(", nullable", dt);
-
-                                if (this.conf.idlOldStyleExceptions && it.raises.length) {
-                                    var table = sn.element("table", { "class": "exceptions" }, desc);
-                                    var tr = sn.element("tr", {}, table);
-                                    ["Exception", "On Get", "On Set", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                    for (var k = 0; k < it.raises.length; k++) {
-                                        var exc = it.raises[k];
-                                        var tr = sn.element("tr", {}, table);
-                                        sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
-                                        ["onGet", "onSet"].forEach(function (gs) {
-                                            if (exc[gs]) sn.element("td", { "class": "excGetSetTrue" }, tr, "\u2714");
-                                            else         sn.element("td", { "class": "excGetSetFalse" }, tr, "\u2718");
-                                        });
-                                        var dtd = sn.element("td", { "class": "excDesc" }, tr);
-                                        if (exc.type == "simple") {
-                                            dtd.appendChild(exc.description);
-                                        }
-                                        else {
-                                            var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
-                                            for (var m = 0; m < exc.description.length; m++) {
-                                                var cd = exc.description[m];
-                                                var tr = sn.element("tr", {}, ctab);
-                                                sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
-                                                sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+                                    else {
+					sn.element("div", {}, desc, [sn.element("em", {}, null, "No parameters.")]);
+                                    }
+                                    if (this.conf.idlOldStyleExceptions && it.raises.length) {
+					var table = sn.element("table", { "class": "exceptions" }, desc);
+					var tr = sn.element("tr", {}, table);
+					["Exception", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+					for (var k = 0; k < it.raises.length; k++) {
+                                            var exc = it.raises[k];
+                                            var tr = sn.element("tr", {}, table);
+                                            sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
+                                            var dtd = sn.element("td", { "class": "excDesc" }, tr);
+                                            if (exc.type == "simple") {
+						$(dtd).append(exc.description);
                                             }
-                                        }
+                                            else {
+						var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
+						for (var m = 0; m < exc.description.length; m++) {
+                                                    var cd = exc.description[m];
+                                                    var tr = sn.element("tr", {}, ctab);
+                                                    sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
+                                                    sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+						}
+                                            }
+					}
                                     }
-                                }
-                                // else {
-                                //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
-                                // }
-                            }
-                            else if (type == "constant") {
-                                sn.text(" of type ", dt);
-                                sn.element("span", { "class": "idlConstType" }, dt, [sn.element("a", {}, null, it.datatype)]);
-                                if (it.nullable) sn.text(", nullable", dt);
-                            }
-                            else if (type == "serializer") {
+                                    // else {
+                                    //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
+                                    // }
 
+                                    var reDiv = sn.element("div", {}, desc);
+                                    sn.element("em", {}, reDiv, "Return type: ");
+
+                                    var code = sn.element("code", {}, reDiv);
+                                    code.innerHTML = datatype(it.datatype);
+                                    if (it.array) code.innerHTML += arrsq(it);
+                                    if (it.nullable) sn.text(", nullable", reDiv);
+				}
+				else if (type == "attribute") {
+                                    sn.text(" of type ", dt);
+                                    if (it.array) {
+					for (var m = 0, n = it.arrayCount; m < n; m++) sn.text("array of ", dt);
+                                    }
+                                    var span = sn.element("span", { "class": "idlAttrType" }, dt);
+                                    var matched = /^sequence<(.+)>$/.exec(it.datatype);
+                                    if (matched) {
+					sn.text("sequence<", span);
+					sn.element("a", {}, span, matched[1]);
+					sn.text(">", span);
+                                    }
+                                    else {
+					sn.element("a", {}, span, it.datatype);
+                                    }
+                                    if (it.readonly) sn.text(", readonly", dt);
+                                    if (it.nullable) sn.text(", nullable", dt);
+
+                                    if (this.conf.idlOldStyleExceptions && it.raises.length) {
+					var table = sn.element("table", { "class": "exceptions" }, desc);
+					var tr = sn.element("tr", {}, table);
+					["Exception", "On Get", "On Set", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+					for (var k = 0; k < it.raises.length; k++) {
+                                            var exc = it.raises[k];
+                                            var tr = sn.element("tr", {}, table);
+                                            sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
+                                            ["onGet", "onSet"].forEach(function (gs) {
+						if (exc[gs]) sn.element("td", { "class": "excGetSetTrue" }, tr, "\u2714");
+						else         sn.element("td", { "class": "excGetSetFalse" }, tr, "\u2718");
+                                            });
+                                            var dtd = sn.element("td", { "class": "excDesc" }, tr);
+                                            if (exc.type == "simple") {
+						dtd.appendChild(exc.description);
+                                            }
+                                            else {
+						var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
+						for (var m = 0; m < exc.description.length; m++) {
+                                                    var cd = exc.description[m];
+                                                    var tr = sn.element("tr", {}, ctab);
+                                                    sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
+                                                    sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+						}
+                                            }
+					}
+                                    }
+                                    // else {
+                                    //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
+                                    // }
+				}
+				else if (type == "constant") {
+                                    sn.text(" of type ", dt);
+                                    sn.element("span", { "class": "idlConstType" }, dt, [sn.element("a", {}, null, it.datatype)]);
+                                    if (it.nullable) sn.text(", nullable", dt);
+				}
+                            }
+			} 
+			else { // Serializer 
+			    var div = sn.element("div", {}, sec);
+			    if (it.serializertype != "prose") {
+				var generatedDescription = "Instances of this interface are serialized as ";
+				if (it.serializertype == "map") {
+				    var mapDescription = "a map ";
+				    if (it.getter) {
+					mapDescription += "with entries corresponding to the named properties";
+				    }
+				    else {
+					var and = "";
+					if (it.inherit) {
+					    mapDescription += "with entries from the closest inherited interface ";
+					    and = "and ";
+					}
+					if (it.all) {
+					    mapDescription += and + "with entries for each of the serializable attributes";
+					} else if (it.values && it.values.length) {
+					    mapDescription += and + "with entries for the following attributes: " + it.values.join(", ");
+					} else {
+					    mapDescription = "an empty map";
+					}
+				    }
+				    generatedDescription += mapDescription;
+				}
+				else if (it.serializertype == "list") {
+				    var listDescription = "a list ";
+				    if (it.getter) {
+					listDescription += "with values corresponding to the indexed properties";
+				    }
+				    else {
+					if (it.values && it.values.length) {
+					    listDescription += "with the values of the following attributes: " + it.values.join(", ");
+					} else {
+					    mapDescription = "an empty list";
+					}
+				    }
+				    generatedDescription += listDescription;
+				}
+				else if (it.serializertype == "attribute") {
+				    generatedDescription += "the value of the attribute " + it.values[0];
+				}
+				generatedDescription += ".";
+				var p = sn.element("p", {}, div, generatedDescription);
 			    }
-                        }
-                    }
-                    if (typeof obj.merge !== "undefined" && obj.merge.length > 0) {
+			    var desc = sn.element("p", {}, div, [it.description]);
+			}
+		    }
+		    if (typeof obj.merge !== "undefined" && obj.merge.length > 0) {
                         // hackish: delay the execution until the DOM has been initialized, then merge
                         setTimeout(function () {
                             for (var i = 0; i < obj.merge.length; i++) {
@@ -1026,8 +1080,8 @@ define(
                     ,   maxAttr = 0, maxMeth = 0, maxConst = 0, hasRO = false;
                     obj.children.forEach(function (it, idx) {
                         var len = 0;
-                        if (it.isUnionType) len = it.datatype.join(" or ").length + 2;
-                        else                len = it.datatype.length;
+                        if (it.isUnionType)   len = it.datatype.join(" or ").length + 2;
+                        else if (it.datatype) len = it.datatype.length;
                         if (it.isStatic) len += 7;
                         if (it.nullable) len = len + 1;
                         if (it.array) len = len + (2 * it.arrayCount);
@@ -1043,6 +1097,7 @@ define(
                                           if (ch.type == "attribute") return self.writeAttribute(ch, maxAttr, indent + 1, curLnk, hasRO);
                                           else if (ch.type == "method") return self.writeMethod(ch, maxMeth, indent + 1, curLnk);
                                           else if (ch.type == "constant") return self.writeConst(ch, maxConst, indent + 1, curLnk);
+                                          else if (ch.type == "serializer") return self.writeSerializer(ch, indent + 1, curLnk);
                                       })
                                       .join("")
                     ;
@@ -1189,6 +1244,33 @@ define(
                 var pad = max - cons.datatype.length;
                 if (cons.nullable) pad--;
                 return idlConstTmpl({ obj: cons, indent: indent, pad: pad, nullable: cons.nullable ? "?" : ""});
+            },
+
+
+            writeSerializer: function (serializer, indent, curLnk) {
+		var values = "";
+		if (serializer.serializertype == "map") {
+		    var mapValues = [];
+		    if (serializer.getter) mapValues = ["getter"];
+		    else {
+			if (serializer.inherit) mapValues.push("inherit");
+			if (serializer.all) mapValues.push("attribute");
+			else                mapValues = mapValues.concat(serializer.values);
+		    }
+		    values = "{" + mapValues.join(", ") + "}";
+		} 
+		else if (serializer.serializertype == "list") {
+		    var listValues = (serializer.getter ? ["getter"] : serializer.values);
+		    values = "[" + listValues.join(", ") + "]";
+		}
+		else if (serializer.serializertype == "attribute") {
+		    values = serializer.values[0];
+		}
+                return idlSerializerTmpl({
+                    obj:        serializer
+                ,   indent:     indent
+		,   values:     values
+                });
             },
 
             writeMember:    function (memb, max, indent, curLnk) {

--- a/tests/spec/core/webidl-oldschool-spec.js
+++ b/tests/spec/core/webidl-oldschool-spec.js
@@ -140,6 +140,20 @@ describe("Core - WebIDL", function () {
         expect($lst.find(".idlParam").first().find(".idlParamType > a").text()).toEqual("Date");
     });
 
+    it("should handle serializer", function () {
+        $target = $("#serializer-map", doc);
+        text =  "interface SuperStar {\n" +
+                "             attribute DOMString foo;\n" +
+                "             attribute DOMString bar;\n" +
+ 	        "    serializer = {foo, bar};\n" +
+                "};";
+        expect($target.text()).toEqual(text);
+        expect($target.find(".idlSerializer").length).toEqual(1);
+        var $serializer = $target.find(".idlSerializer").first();
+        expect($serializer.find(".idlSerializerValues").text()).toEqual("{foo, bar}");
+    });
+
+
     it("should handle dictionaries", function () {
         $target = $("#dict-basic", doc);
         text = "dictionary SuperStar {\n};";

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -231,6 +231,14 @@
       </dl>
     </section>
     <section>
+      <h2>Serializer</h2>
+      <dl id='serializer-map' class='idl' title='interface SuperStar'>
+	<dt>attribute DOMString foo</dt>
+	<dt>attribute DOMString bar</dt>
+        <dt>serializer = { foo, bar }</dt>
+      </dl>
+    </section>
+    <section>
       <h2>Dictionaries</h2>
       <p>
         Basic dictionary.


### PR DESCRIPTION
[WebIDL](http://dev.w3.org/2006/webapi/WebIDL/#idl-serializers) has syntax to declare serializers, which at least the WebRTC spec intends to use. This patch adds support for serializer to the webidl module of respec.
