### PR TITLE
Add support for 'scheme' config variable: if defined, loads external res...

### DIFF
--- a/js/core/base-runner.js
+++ b/js/core/base-runner.js
@@ -99,7 +99,7 @@ define(
                     if (/\/js\//.test(src)) baseUrl = src.replace(/\/js\/.*/, "\/js\/");
                 });
                 respecConfig.respecBase = baseUrl;
-                respecConfig.scheme = location.protocol.replace(":", "").toLowerCase();
+                respecConfig.scheme = (respecConfig.scheme) ? respecConfig.scheme : location.protocol.replace(":", "").toLowerCase();
                 respecConfig.httpScheme = (respecConfig.scheme === "https") ? "https" : "http";
                 
                 var pipeline;


### PR DESCRIPTION
...ources using the defined scheme instead of the scheme acquired via location.protocol. Values 'http' and 'https' are supported.
