### PR TITLE
Allow comments on interfaces

### DIFF
--- a/js/core/css/webidl-oldschool.css
+++ b/js/core/css/webidl-oldschool.css
@@ -80,6 +80,11 @@ a.idlEnumItem {
     color:  #666;
 }
 
+/*.idlSectionComment*/
+.idlSectionComment {
+    color: gray;
+}
+
 /*.idlConst*/
 .idlConstType {
     color:  #005a9c;

--- a/js/core/templates/webidl/comment.html
+++ b/js/core/templates/webidl/comment.html
@@ -1,0 +1,2 @@
+<span class='idlSectionComment'>{{extAttr obj indent true
+}}{{idn indent}}// {{comment}}</span>

--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -24,13 +24,14 @@ define(
     ,   "tmpl!core/templates/webidl/method.html"
     ,   "tmpl!core/templates/webidl/attribute.html"
     ,   "tmpl!core/templates/webidl/serializer.html"
+    ,   "tmpl!core/templates/webidl/comment.html"
     ,   "tmpl!core/templates/webidl/field.html"
     ,   "tmpl!core/templates/webidl/exception.html"
     ,   "tmpl!core/templates/webidl/interface.html"
     ],
     function (hb, css, idlModuleTmpl, idlTypedefTmpl, idlImplementsTmpl, idlDictMemberTmpl, idlDictionaryTmpl,
                    idlEnumItemTmpl, idlEnumTmpl, idlConstTmpl, idlParamTmpl, idlCallbackTmpl, idlMethodTmpl,
-              idlAttributeTmpl, idlSerializerTmpl, idlFieldTmpl, idlExceptionTmpl, idlInterfaceTmpl) {
+              idlAttributeTmpl, idlSerializerTmpl, idlCommentTmpl, idlFieldTmpl, idlExceptionTmpl, idlInterfaceTmpl) {
         var WebIDLProcessor = function (cfg) {
                 this.parent = { type: "module", id: "outermost", children: [] };
                 if (!cfg) cfg = {};
@@ -574,6 +575,14 @@ define(
                     return obj;
                 }
 
+                // COMMENT
+                match = /^\s*\/\/\s*(.*)\s*$/.exec(str);
+                if (match) {
+                    obj.type = "comment";
+                    obj.id = match[1];
+                    return obj;
+                }
+
                 // NOTHING MATCHED
                 this.msg.pub("error", "Expected interface member, got: " + str);
             },
@@ -1107,6 +1116,7 @@ define(
                                           else if (ch.type == "method") return self.writeMethod(ch, maxMeth, indent + 1, curLnk);
                                           else if (ch.type == "constant") return self.writeConst(ch, maxConst, indent + 1, curLnk);
                                           else if (ch.type == "serializer") return self.writeSerializer(ch, indent + 1, curLnk);
+                                          else if (ch.type == "comment") return self.writeComment(ch, indent + 1);
                                       })
                                       .join("")
                     ;
@@ -1256,6 +1266,10 @@ define(
                 var pad = max - cons.datatype.length;
                 if (cons.nullable) pad--;
                 return idlConstTmpl({ obj: cons, indent: indent, pad: pad, nullable: cons.nullable ? "?" : ""});
+            },
+
+            writeComment:   function (comment, indent) {
+                return idlCommentTmpl({ obj: comment, indent: indent, comment: comment.id});
             },
 
 

--- a/tests/spec/core/webidl-oldschool-spec.js
+++ b/tests/spec/core/webidl-oldschool-spec.js
@@ -153,6 +153,16 @@ describe("Core - WebIDL", function () {
         expect($serializer.find(".idlSerializerValues").text()).toEqual("{foo, bar}");
     });
 
+    it("should handle comments", function () {
+        $target = $("#comments-basic", doc);
+        text =  "interface SuperStar {\n" +
+                "    // This is a comment\n" +
+                "    // over two lines.\n" +
+                "};";
+        expect($target.text()).toEqual(text);
+        expect($target.find(".idlSectionComment").length).toEqual(2);
+    });
+
 
     it("should handle dictionaries", function () {
         $target = $("#dict-basic", doc);

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -239,6 +239,15 @@
       </dl>
     </section>
     <section>
+      <h2>Comments</h2>
+      <dl id="comments-basic" class='idl' title='interface SuperStar'>
+        <dt>// This is a comment</dt>
+        <dd></dd>
+        <dt>// over two lines.</dt>
+        <dd></dd>
+      </dl>
+    </section>
+    <section>
       <h2>Dictionaries</h2>
       <p>
         Basic dictionary.


### PR DESCRIPTION
This allows comments to be added to interfaces. This recovers the functionality of the old respec tool for commenting.
