### PR TITLE
Allow keywords stringifier and inherit on attribute

### DIFF
--- a/js/core/templates/webidl/attribute.html
+++ b/js/core/templates/webidl/attribute.html
@@ -1,3 +1,3 @@
 <span class='idlAttribute'>{{extAttr obj indent true
-}}{{idn indent}}{{readonly}} attribute <span class='idlAttrType'>{{datatype obj.datatype}}{{arr}}{{nullable}}</span> {{pads
+}}{{idn indent}}{{declaration}} attribute <span class='idlAttrType'>{{datatype obj.datatype}}{{arr}}{{nullable}}</span> {{pads
 pad}}<span class='idlAttrName'><a href='#{{href}}'>{{obj.id}}</a></span>;</span>

--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -418,10 +418,11 @@ define(
                 var match;
 
                 // ATTRIBUTE
-                match = /^\s*(?:(readonly)\s+)?attribute\s+(.*?)\s+(\S+)\s*$/.exec(str);
+                match = /^\s*(?:(readonly|inherit|stringifier)\s+)?attribute\s+(.*?)\s+(\S+)\s*$/.exec(str);
                 if (match) {
                     obj.type = "attribute";
-                    obj.readonly = (match[1] === "readonly");
+                    obj.declaration = match[1] ? match[1] : "";
+                    obj.declaration += (new Array(12-obj.declaration.length)).join(" "); // fill string with spaces
                     var type = match[2];
                     this.parseDatatype(obj, type);
                     this.setID(obj, match[3]);
@@ -936,7 +937,7 @@ define(
                                     else {
                                         sn.element("a", {}, span, it.isUnionType ? "(" + it.datatype.join(" or ") + ")" : it.datatype);
                                     }
-                                    if (it.readonly) sn.text(", readonly", dt);
+                                    if (it.declaration) sn.text(", " + it.declaration, dt);
                                     if (it.nullable) sn.text(", nullable", dt);
 
                                     if (this.conf.idlOldStyleExceptions && it.raises.length) {
@@ -1097,7 +1098,7 @@ define(
                         if (it.type == "attribute") maxAttr = (len > maxAttr) ? len : maxAttr;
                         else if (it.type == "method") maxMeth = (len > maxMeth) ? len : maxMeth;
                         else if (it.type == "constant") maxConst = (len > maxConst) ? len : maxConst;
-                        if (it.type == "attribute" && it.readonly) hasRO = true;
+                        if (it.type == "attribute" && it.declaration) hasRO = true;
                     });
                     var curLnk = "widl-" + obj.refId + "-"
                     ,   self = this
@@ -1211,13 +1212,13 @@ define(
                 if (attr.nullable) pad = pad - 1;
                 if (attr.array) pad = pad - (2 * attr.arrayCount);
                 return idlAttributeTmpl({
-                    obj:        attr
-                ,   indent:     indent
-                ,   readonly:   attr.readonly ? "readonly" : "        "
-                ,   pad:        pad
-                ,   arr:        arrsq(attr)
-                ,   nullable:   attr.nullable ? "?" : ""
-                ,   href:       curLnk + attr.refId
+                    obj:            attr
+                ,   indent:         indent
+                ,   declaration:    attr.declaration
+                ,   pad:            pad
+                ,   arr:            arrsq(attr)
+                ,   nullable:       attr.nullable ? "?" : ""
+                ,   href:           curLnk + attr.refId
                 });
             },
 

--- a/tests/spec/core/webidl-oldschool-spec.js
+++ b/tests/spec/core/webidl-oldschool-spec.js
@@ -94,14 +94,16 @@ describe("Core - WebIDL", function () {
     it("should handle attributes", function () {
         $target = $("#attr-basic", doc);
         text =  "interface SuperStar {\n" +
-                "             attribute DOMString      regular;\n" +
-                "    readonly attribute DOMString      ro;\n" +
+                "                attribute DOMString      regular;\n" +
+                "    readonly    attribute DOMString      ro;\n" +
+                "    inherit     attribute DOMString      in;\n" +
+                "    stringifier attribute DOMString      st;\n" +
                 "    [Something]\n" +
-                "    readonly attribute DOMString      ext;\n" +
-                "             attribute sequence<Date> dates;\n" +
+                "    readonly    attribute DOMString      ext;\n" +
+                "                attribute sequence<Date> dates;\n" +
                 "};";
         expect($target.text()).toEqual(text);
-        expect($target.find(".idlAttribute").length).toEqual(4);
+        expect($target.find(".idlAttribute").length).toEqual(6);
         var $at = $target.find(".idlAttribute").first();
         expect($at.find(".idlAttrType").text()).toEqual("DOMString");
         expect($at.find(".idlAttrName").text()).toEqual("regular");
@@ -110,8 +112,8 @@ describe("Core - WebIDL", function () {
         expect($lst.find(".idlAttrType > a").text()).toEqual("Date");
         
         var $sec = $("#attributes-1 dl.attributes", doc);
-        expect($sec.find("dt").length).toEqual(4);
-        expect($sec.find("dd").length).toEqual(4);
+        expect($sec.find("dt").length).toEqual(6);
+        expect($sec.find("dd").length).toEqual(6);
         expect($sec.find("dt").first().find("code").first().text()).toEqual("dates");
         expect($sec.find("dt").first().find(".idlAttrType a").text()).toEqual("Date");
         expect($sec.find("dd").first().text()).toEqual("3.5");
@@ -143,8 +145,8 @@ describe("Core - WebIDL", function () {
     it("should handle serializer", function () {
         $target = $("#serializer-map", doc);
         text =  "interface SuperStar {\n" +
-                "             attribute DOMString foo;\n" +
-                "             attribute DOMString bar;\n" +
+                "                attribute DOMString foo;\n" +
+                "                attribute DOMString bar;\n" +
                 "    serializer = {foo, bar};\n" +
                 "};";
         expect($target.text()).toEqual(text);

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -144,6 +144,10 @@
         <dd>1</dd>
         <dt>readonly attribute DOMString ro</dt>
         <dd>2</dd>
+        <dt>inherit attribute DOMString in</dt>
+        <dd>2.5</dd>
+        <dt>stringifier attribute DOMString st</dt>
+        <dd>2.7</dd>
         <dt>[Something] readonly attribute DOMString ext</dt>
         <dd>3</dd>
         <dt>attribute sequence&lt;Date> dates</dt>


### PR DESCRIPTION
The WebIDL specification allows the keywords readonly, inherit and stringifier for attributes. The former was supported already. This patch adds support for the other two.
