### PR TITLE
Allow issues to be marked atrisk

### DIFF
--- a/js/core/issues-notes.js
+++ b/js/core/issues-notes.js
@@ -26,11 +26,13 @@ define(
                     $ins.each(function (i, inno) {
                         var $inno = $(inno)
                         ,   isIssue = $inno.hasClass("issue")
+                        ,   isFeatureAtRisk = $inno.hasClass("atrisk")
                         ,   isInline = $inno.css("display") != "block"
                         ,   dataNum = $inno.attr("data-number")
                         ,   report = { inline: isInline, content: $inno.html() }
                         ;
                         report.type = isIssue ? "issue" : "note";
+
                         if (isIssue && !isInline && !hasDataNum) {
                             issueNum++;
                             report.number = issueNum;
@@ -38,20 +40,22 @@ define(
                         else if (dataNum) {
                             report.number = dataNum;
                         }
-                
+
                         // wrap
                         if (!isInline) {
-                            var $div = $("<div class='" + report.type + "'></div>")
+                            var $div = $("<div class='" + report.type + (isFeatureAtRisk ? " atrisk" : "") + "'></div>")
                             ,   $tit = $("<div class='" + report.type + "-title'><span></span></div>")
-                            ,   text = isIssue ? "Issue" : "Note"
+                            ,   text = isIssue ? (isFeatureAtRisk ? "Feature at Risk" : "Issue") : "Note"
                             ;
                             if (isIssue) {
                                 if (hasDataNum) {
                                     if (dataNum) {
                                       text += " " + dataNum;
                                       // Set issueBase to cause issue to be linked to the external issue tracker
-                                      if (conf.issueBase) {
+                                      if (!isFeatureAtRisk && conf.issueBase) {
                                         $tit.find("span").wrap($("<a href='" + conf.issueBase + dataNum + "'/>"))
+                                      } else if (isFeatureAtRisk && conf.atRiskBase) {
+                                        $tit.find("span").wrap($("<a href='" + conf.atRiskBase + dataNum + "'/>"))
                                       }
                                     }
                                 }

--- a/tests/spec/core/issues-notes-spec.js
+++ b/tests/spec/core/issues-notes-spec.js
@@ -8,6 +8,12 @@ describe("Core — Issues and Notes", function () {
             editors:    [{ name: "Gregg Kellogg" }]
         ,   issueBase:  "http://example.com/issues/"
         ,   specStatus: "WD"
+      }
+    ,   atRiskBaseConfig = {
+            editors:    [{ name: "Markus Lanthaler" }]
+        ,   issueBase:  "http://example.com/issues/"
+        ,   atRiskBase: "http://example.com/atrisk/"
+        ,   specStatus: "WD"
       };
     it("should process issues and notes", function () {
         var doc;
@@ -15,27 +21,39 @@ describe("Core — Issues and Notes", function () {
             makeRSDoc({
                         config: basicConfig
                     ,   body: $("<section><p>BLAH <span class='issue'>ISS-INLINE</span></p><p class='issue' title='ISS-TIT'>ISSUE</p>" +
+                                "<p>BLAH <span class='issue atrisk'>ATR-INLINE</span></p><p class='issue atrisk' title='ATR-TIT'>FEATURE AT RISK</p>" +
                                 "<p>BLAH <span class='note'>NOT-INLINE</span></p><p class='note' title='NOT-TIT'>NOTE</p></section>")
                     },
                     function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {
-            var $iss = $("div.issue", doc)
+            var $iss = $("div.issue", doc).first()
+            ,   $atr = $("div.atrisk", doc)
             ,   $piss = $iss.find("p")
+            ,   $patr = $atr.find("p")
             ,   $spiss = $("span.issue", doc)
+            ,   $spatr = $("span.atrisk", doc)
             ,   $not = $("div.note", doc)
             ,   $pnot = $not.find("p")
             ,   $spnot = $("span.note", doc)
             ;
 
+            console.log(doc);
+
             expect($spiss.parent("div").length).toEqual(0);
+            expect($spatr.parent("div").length).toEqual(0);
             expect($spnot.parent("div").length).toEqual(0);
 
             expect($iss.find("div.issue-title").length).toEqual(1);
             expect($iss.find("div.issue-title").text()).toEqual("Issue 1: ISS-TIT");
             expect($piss.attr("title")).toBeUndefined();
             expect($piss.text()).toEqual("ISSUE");
+
+            expect($atr.find("div.issue-title").length).toEqual(1);
+            expect($atr.find("div.issue-title").text()).toEqual("Feature at Risk 2: ATR-TIT");
+            expect($patr.attr("title")).toBeUndefined();
+            expect($patr.text()).toEqual("FEATURE AT RISK");
 
             expect($not.find("div.note-title").length).toEqual(1);
             expect($not.find("div.note-title").text()).toEqual("Note: NOT-TIT");
@@ -91,6 +109,29 @@ describe("Core — Issues and Notes", function () {
             expect($iss.find("div.issue-title a").attr("href")).toEqual(issueBaseConfig.issueBase + "10");
             expect($piss.attr("title")).toBeUndefined();
             expect($piss.text()).toEqual("ISSUE");
+            flushIframes();
+        });
+    });
+   it("should link to external issue tracker for features at risk", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({
+                        config: atRiskBaseConfig
+                    ,   body: $("<section><p class='issue atrisk' data-number='10'>FEATURE AT RISK</p></section>")
+                    },
+                    function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $iss = $("div.atrisk", doc)
+            ,   $piss = $iss.find("p")
+            ;
+
+            expect($iss.find("div.issue-title").length).toEqual(1);
+            expect($iss.find("div.issue-title").text()).toEqual("Feature at Risk 10");
+            expect($iss.find("div.issue-title a").attr("href")).toEqual(atRiskBaseConfig.atRiskBase + "10");
+            expect($piss.attr("title")).toBeUndefined();
+            expect($piss.text()).toEqual("FEATURE AT RISK");
             flushIframes();
         });
     });


### PR DESCRIPTION
This represent a feature at risk. I also introduced a new configuration setting "atRiskBase" which allows similarly to "issueBase" to set the base URL to prepend to the issue number. Features at risk are often managed separately.

It would be great if this could released soon since we need it for the JSON-LD specification.

Thanks
