### PR TITLE
Ensure that URL fragment identifiers work as intended

### DIFF
--- a/js/core/location-hash.js
+++ b/js/core/location-hash.js
@@ -1,0 +1,30 @@
+
+// Module core/location-hash
+// Resets window.location.hash to jump to the right point in the document
+
+define(
+    [],
+    function () {
+        return {
+            run:    function (conf, doc, cb, msg) {
+                msg.pub("start", "core/location-hash");
+                var hash = window.location.hash;
+
+                // Number of pixels that the document has already been
+                // scrolled vertically (cross-browser)
+                var scrollY = (window.pageYOffset !== undefined)
+                    ? window.pageYOffset
+                    : (document.documentElement || document.body.parentNode || document.body).scrollTop;
+
+                // Only scroll to the hash if the document hasn't been scrolled yet
+                // this ensures that a page refresh maintains the scroll position
+                if (hash && !scrollY) {
+                    window.location.hash = "";
+                    window.location.hash = hash;
+                }
+                msg.pub("end", "core/location-hash");
+                cb();
+            }
+        };
+    }
+);

--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -29,6 +29,7 @@ define([
         ,   "core/section-refs"
         ,   "core/id-headers"
         ,   "core/remove-respec"
+        ,   "core/location-hash"
         ],
         function (domReady, runner) {
             var args = Array.prototype.slice.call(arguments)


### PR DESCRIPTION
Currently, in most cases, URL fragment identifiers don't work as intended as the target doesn't exist yet. This module re-sets window.location.hash to jump to the right position in the document. It does this only if the document hasn't been scrolled down yet to ensure that page refreshs maintain the scroll position.
