### PR TITLE
Use scheme-relative stylesheet URLs

### DIFF
--- a/js/w3c/style.js
+++ b/js/w3c/style.js
@@ -18,21 +18,21 @@ define(
                     statStyle === "LC-NOTE") statStyle = "WD";
                 if (statStyle === "FPWD-NOTE") statStyle = "WG-NOTE";
                 if (statStyle === "finding" || statStyle === "draft-finding") statStyle = "base";
-                var css;
+                var css = ('http' !== conf.scheme.substring(0, 4)) ? 'http://' : '//';
                 if (statStyle === "unofficial") {
-                    css = "//www.w3.org/StyleSheets/TR/w3c-unofficial";
+                    css += "www.w3.org/StyleSheets/TR/w3c-unofficial";
                 }
                 else if (statStyle === "base") {
-                    css = "//www.w3.org/StyleSheets/TR/base";
+                    css += "www.w3.org/StyleSheets/TR/base";
                 }
                 else if (statStyle === "CG-DRAFT" || statStyle === "CG-FINAL" ||
                          statStyle === "BG-DRAFT" || statStyle === "BG-FINAL") {
                     // note: normally, the ".css" is not used in W3C, but here specifically it clashes
                     // with a PNG of the same base name. CONNEG must die.
-                    css = "//www.w3.org/community/src/css/spec/" + statStyle.toLowerCase() + ".css";
+                    css += "www.w3.org/community/src/css/spec/" + statStyle.toLowerCase() + ".css";
                 }
                 else {
-                    css = "//www.w3.org/StyleSheets/TR/W3C-" + statStyle;
+                    css += "www.w3.org/StyleSheets/TR/W3C-" + statStyle;
                 }
                 utils.linkCSS(doc, css);
                 msg.pub("end", "w3c/style");


### PR DESCRIPTION
The current code is problematic when code is saved locally (e.g., using http://localhost) and then pushed to a server using https. This change makes sure that the stylesheets use the same scheme as the document itself.
