### PR TITLE
fix type of Signature Properties to REC

### DIFF
--- a/bibref/biblio.js
+++ b/bibref/biblio.js
@@ -7953,7 +7953,7 @@ berjon.biblio = {
         "href": "http://www.w3.org/TR/2013/REC-xmldsig-properties-20130411/",
         "title": "XML Signature Properties",
         "date": "11 April 2013",
-        "status": "PR",
+        "status": "REC",
         "publisher": "W3C"
     },
     "XMLDSIG-REQUIREMENTS": {


### PR DESCRIPTION
You may have already done this  manually, but I finally have a clean in-sync origin with this outstanding change, only to update the type to REC
