### PR TITLE
Changed the @role attribute on the table of contents and the IDs on major sections

### DIFF
--- a/js/w3c/aria.js
+++ b/js/w3c/aria.js
@@ -25,12 +25,17 @@ define(
                 });
                 // ensure head section is labelled
                 $('body', doc).attr('role', 'document') ;
-                $('body', doc).attr('id', 'theDocument') ;
+                $('body', doc).attr('id', 'respecDocument') ;
                 $('div.head', doc).attr('role', 'contentinfo') ;
-                $('div.head', doc).attr('id', 'theHeader') ;
+                $('div.head', doc).attr('id', 'respecHeader') ;
                 if (!conf.noTOC) {
                     // ensure toc is labelled
-                    $('section#toc', doc).attr('role', 'directory') ;
+                    var toc = $('section#toc', doc)
+                                  .find("ul:first");
+                    toc.attr('role', 'directory') ;
+                    if (!toc.attr("id")) {
+                        toc.attr('id', 'respecContents') ;
+                    }
                 }
                 // mark issues and notes with heading
                 var noteNum = 0, issueNum = 0;

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -25,6 +25,7 @@ describe("Core - Structure", function () {
             expect($toc.find("h2").text()).toEqual("Table of Contents");
             expect($toc.find("h2").attr('role')).toEqual('heading');
             expect($toc.find("h2").attr('aria-level')).toEqual('1');
+            expect($toc.find("ul:first").attr('role')).toEqual('directory');
             expect($toc.find("> ul > li").length).toEqual(3);
             expect($toc.find("li").length).toEqual(15);
             expect($toc.find("> ul > li a").first().text()).toEqual("1. ONE");


### PR DESCRIPTION
The definition of @role in HTML5 requires that the values of @role on the section element not 
be 'directory'.  This change pushes the role attribute onto the enclosing ul element of the actual table of contents so it will be valid HTML5.
