### PR TITLE
Serve JavaScript from GitHub Pages.

### DIFF
--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -10,7 +10,7 @@ var requireConfig = {
 };
 if ("respecVersion" in window && respecVersion) {
     requireConfig.paths = {
-        "ui":   "https://raw.github.com/darobin/respec/gh-pages/js/ui"
+        "ui":   "https://darobin.github.io/respec/js/ui"
     };
 }
 require.config(requireConfig);


### PR DESCRIPTION
'raw.github.com' serves JavaScript as text/plain, and includes headers
which prevent browsers like Chrome and IE from sniffing those resources
into something executable.

Replacing the 'raw.github.com' URL with the 'darobin.github.io' version
allows UI affordances like 'Save' to properly download and execute new
resources.
