### PR TITLE
WCAG2.0-compliant luminosity contrast for <code>

### DIFF
--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -41,7 +41,7 @@ cite .bibref {
 }
 
 code {
-    color:  #ff4500;
+    color:  #dc3b00;
 }
 
 /* --- TOC --- */


### PR DESCRIPTION
# ff4500 has luminosity contrast of 3.4:1. Need at least 4.5:1. Use #dc3b00.
