### PR TITLE
More accessible luminosity contrast on colour for <code>

### DIFF
--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -41,7 +41,7 @@ cite .bibref {
 }
 
 code {
-    color:  #dc3b00;
+    color:  #C83500;
 }
 
 /* --- TOC --- */


### PR DESCRIPTION
The red used for &lt;code&gt; is a little low on contrast and doesn't meet the WCAG 2.0 AA requirement for a minimum 4.5:1 contrast. This fixes that with a darker version of the same red.
