### PR TITLE
Support Previous Version on NOTEs

### DIFF
--- a/js/w3c/headers.js
+++ b/js/w3c/headers.js
@@ -310,7 +310,7 @@ define(
                     conf.rdfStatus = this.status2rdf[conf.specStatus];
                 }
                 conf.showThisVersion =  (!conf.isNoTrack || conf.isTagFinding);
-                conf.showPreviousVersion = (/NOTE$/.test(conf.specStatus) === false && conf.specStatus !== "FPWD" && conf.specStatus !== "FPLC" && conf.specStatus !== "ED" &&
+                conf.showPreviousVersion = (conf.specStatus !== "FPWD" && conf.specStatus !== "FPLC" && conf.specStatus !== "ED" &&
                                            !conf.isNoTrack);
                 if (conf.isTagFinding) conf.showPreviousVersion = conf.previousPublishDate ? true : false;
                 conf.notYetRec = (conf.isRecTrack && conf.specStatus !== "REC");


### PR DESCRIPTION
As per a discussion on spec-prod, NOTEs can have Previous Versions, so we need to support output of that header too.
