### PR TITLE
Change text to be clearer by using 'oxford' comma

### DIFF
--- a/js/w3c/templates/sotd.html
+++ b/js/w3c/templates/sotd.html
@@ -69,7 +69,7 @@
         {{#if notRec}}
           <p>
             Publication as {{anOrA}} {{textStatus}} does not imply endorsement by the W3C
-            Membership. This is a draft document and may be updated, replaced or obsoleted by other
+            Membership. This is a draft document and may be updated, replaced, or obsoleted by other
             documents at any time. It is inappropriate to cite this document as other than work in
             progress.
           </p>


### PR DESCRIPTION
The sentence "This is a draft document and may be updated, replaced or obsoleted by other documents at any time." should read "This is a draft document and may be updated, replaced, or obsoleted by other documents at any time."
