### PR TITLE
Ensured whitespace is collapsed in terms

### DIFF
--- a/js/core/inlines.js
+++ b/js/core/inlines.js
@@ -59,6 +59,7 @@ define(
                         if (matched) {
                             // RFC 2119
                             if (/MUST(?:\s+NOT)?|SHOULD(?:\s+NOT)?|SHALL(?:\s+NOT)?|MAY|(?:NOT\s+)?REQUIRED|(?:NOT\s+)?RECOMMENDED|OPTIONAL/.test(matched)) {
+                                matched = matched.split(/\s+/).join(" ");
                                 df.appendChild($("<em/>").attr({ "class": "rfc2119", title: matched }).text(matched)[0]);
                                 // remember which ones were used
                                 if (conf.respecRFC2119[matched]) {

--- a/js/w3c/rfc2119.js
+++ b/js/w3c/rfc2119.js
@@ -11,7 +11,7 @@ define(
                 if ($confo.length) {
                     // do we have a list of used RFC2119 items in
                     // conf.respecRFC2119
-                    var used = Object.getOwnPropertyNames(conf.respecRFC2119) ;
+                    var used = Object.getOwnPropertyNames(conf.respecRFC2119).sort() ;
                     if (used && used.length) {
                         // put in the 2119 clause and reference
                         var str = "The " ;

--- a/tests/spec/w3c/conformance-spec.js
+++ b/tests/spec/w3c/conformance-spec.js
@@ -25,14 +25,14 @@ describe("W3C — Conformance", function () {
     it("should include only referenced 2119 terms", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='conformance'><p>CONFORMANCE</p></section><section><h2>my section</h2><p>Terms are MUST and SHOULD</p></section>") }, 
+            makeRSDoc({ config: basicConfig, body: $("<section id='conformance'><p>CONFORMANCE</p></section><section><h2>my section</h2><p>Terms are MUST, SHOULD, SHOULD NOT, and SHOULD  NOT.</p></section>") }, 
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {
             var $c = $("#conformance", doc);
             var $d = $(".rfc2119", $c) ;
-            expect($d.length).toEqual(2);
+            expect($d.length).toEqual(3);
             flushIframes();
         });
     });


### PR DESCRIPTION
Also added code to sort the terms before emitting
them and added a test to be sure the whitespace is
really getting removed.
