### PR TITLE
Added control to permit moving custom sotd

### DIFF
--- a/js/w3c/templates/cgbg-sotd.html
+++ b/js/w3c/templates/cgbg-sotd.html
@@ -14,7 +14,9 @@
     Learn more about 
     <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>.
   </p>
+  {{#unless sotdAfterWGinfo}}
   {{{sotdCustomParagraph}}}
+  {{/unless}}
     {{#if wgPublicList}}
       <p>If you wish to make comments regarding this document, please send them to 
       <a href='mailto:{{wgPublicList}}@w3.org{{#if subjectPrefix}}?subject={{subjectPrefixEnc}}{{/if}}'>{{wgPublicList}}@w3.org</a> 
@@ -24,4 +26,7 @@
       with <code>{{subjectPrefix}}</code> at the start of your
       email's subject{{/if}}.</p>
     {{/if}}
+  {{#if sotdAfterWGinfo}}
+  {{{sotdCustomParagraph}}}
+  {{/if}}
 </section>

--- a/js/w3c/templates/sotd.html
+++ b/js/w3c/templates/sotd.html
@@ -25,7 +25,9 @@
           href='http://www.w3.org/TR/'>W3C technical reports index</a> at
           http://www.w3.org/TR/.</em>
         </p>
+        {{#unless sotdAfterWGinfo}}
         {{{sotdCustomParagraph}}}
+        {{/unless}}
         <p>
           This document was published by the {{{wgHTML}}} as {{anOrA}} {{longStatus}}.
           {{#if notYetRec}}
@@ -65,6 +67,9 @@
             Please see the Working Group's  <a href='{{implementationReportURI}}'>implementation
             report</a>.
           </p>
+        {{/if}}
+        {{#if sotdAfterWGinfo}}
+        {{{sotdCustomParagraph}}
         {{/if}}
         {{#if notRec}}
           <p>

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -233,6 +233,20 @@ describe("W3C — Headers", function () {
         });
     });
 
+    // sotdAfterWGinfo
+    it("should relocate custom sotd", function () {
+        loadWithConfig({ sotdAfterWGinfo: true, wg: "WGNAME", wgURI: "WGURI", wgPublicList: "WGLIST", subjectPrefix: "[The Prefix]" }, function ($ifr) {
+            var $sotd = $("#sotd", $ifr[0].contentDocument);
+            console.log($sotd.text());
+            var $f = $($sotd.find("p:contains('CUSTOM PARAGRAPH')")) ;
+            expect($f.length).toEqual(1);
+            var $p = $f.prev() ;
+            expect($("a:contains('WGNAME')", $p).length).toEqual(1);
+            expect($("a:contains('WGNAME')", $p).attr("href")).toEqual("WGURI");
+            expect($("a:contains('WGLIST@w3.org')", $p).attr("href")).toEqual("mailto:WGLIST@w3.org?subject=%5BThe%20Prefix%5D");
+        });
+    });
+
     // charterDisclosureURI
     it("should take charterDisclosureURI into account", function () {
         loadWithConfig({ specStatus: "IG-NOTE", charterDisclosureURI: "URI" }, function ($ifr) {


### PR DESCRIPTION
Added option sotdAfterWGinfo option.   If true, then the custom sotd
paragraph will appear after the information about the working group
and comment email addresses.

This addresses issue #351.
