### PR TITLE
Make sure all arguments pub() passes to postMessage are structured-cloneable.

### DIFF
--- a/js/core/base-runner.js
+++ b/js/core/base-runner.js
@@ -27,7 +27,13 @@
         pub:    function (topic) {
             var args = Array.prototype.slice.call(arguments);
             args.shift();
-            if (embedded && window.postMessage) parent.postMessage({ topic: topic, args: args}, "*");
+            if (embedded && window.postMessage) {
+                // Make sure all args are structured-cloneable.
+                args = args.map(function(arg) {
+                    return (arg.stack || arg) + '';
+                });
+                parent.postMessage({ topic: topic, args: args}, "*");
+            }
             $.each(handlers[topic] || [], function () {
                 this.apply(GLOBAL, args);
             });
@@ -91,7 +97,7 @@ define(
                     }
                 });
                 respecEvents.pub("start", "core/base-runner");
-                
+
                 // the first in the plugs is going to be us
                 plugs.shift();
 


### PR DESCRIPTION
This avoids throwing an exception for code like 'catch(e) { pub("error", e); }'.
