### PR TITLE
chore(tests): lint for console.log in tests

### DIFF
--- a/tests/.eslintrc.yml
+++ b/tests/.eslintrc.yml
@@ -6,6 +6,7 @@ extends:
 parserOptions:
   sourceType: script
 rules:
+  no-console: 1
   no-sparse-arrays: 0
   jasmine/new-line-before-expect: 0
   jasmine/new-line-between-declarations: 0

--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -37,6 +37,7 @@ function makeRSDoc(opts = {}, src = "about-blank.html", style = "") {
       try {
         ifr.style = style;
       } catch ({ message }) {
+        // eslint-disable-next-line no-console
         console.warn(`Could not override iframe style: ${style} (${message})`);
       }
     }

--- a/tests/spec/core/pluralize-spec.js
+++ b/tests/spec/core/pluralize-spec.js
@@ -49,7 +49,6 @@ describe("Core - Pluralize", () => {
     const doc = await makeRSDoc(ops);
 
     const dfn = doc.querySelector("#section dfn");
-    console.log(doc.getElementsByTagName("section"));
     expect(dfn.id).toEqual("dfn-baz"); // uses first data-lt as `id`
     expect(dfn.dataset.lt).toEqual("baz|bars");
     expect(dfn.dataset.plurals.split("|").sort()).toEqual(["bar", "bazs"]);
@@ -225,8 +224,8 @@ describe("Core - Pluralize", () => {
   it("doesn't add singularization when no <a> references singular term", async () => {
     const body = `
       <section id="section">
-        <dfn data-lt="tables">chairs</dfn> can be referenced 
-        as <a>chairs</a> or <a>tables</a> 
+        <dfn data-lt="tables">chairs</dfn> can be referenced
+        as <a>chairs</a> or <a>tables</a>
       </section>
     `;
     const ops = makeStandardOps({ pluralize: true }, body);


### PR DESCRIPTION
A console.log accidentally snuck in. Added linter rule  to check for that in the future. 