### PR TITLE
Remove footnotes and inline issues from TOC

### DIFF
--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -160,6 +160,7 @@ function createTocListItem(header, id) {
 
 /**
  * Replaces any child <a> and <dfn> with <span>.
+ * Removes footnotes and issues
  * @param {HTMLElement} h
  */
 function filterHeader(h) {
@@ -172,6 +173,9 @@ function filterHeader(h) {
     const span = renameElement(dfn, "span");
     span.removeAttribute("id");
   });
+  h.querySelectorAll("span.footnote, span.issue").forEach(elem =>
+    elem.remove()
+  );
 }
 
 export function run(conf) {


### PR DESCRIPTION
Footnotes and inline issues were formerly duplicated if the header/caption/figcaption had them.