### PR TITLE
refactor(respecDocWriter): move write out, use in CLI directly

### DIFF
--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -6,7 +6,8 @@ const finalhandler = require("finalhandler");
 const sade = require("sade");
 const colors = require("colors");
 const marked = require("marked");
-const { toHTML, write } = require("./respecDocWriter.js");
+const { writeFile } = require("fs").promises;
+const { toHTML } = require("./respecDocWriter.js");
 
 class Renderer extends marked.Renderer {
   strong(text) {
@@ -244,4 +245,26 @@ async function run(source, destination, options, log) {
   await write(destination, html);
 
   if (staticServer) await staticServer.stop();
+}
+
+/**
+ * @param {string | "stdout" | null | "" | undefined} destination
+ * @param {string} html
+ */
+async function write(destination, html) {
+  switch (destination) {
+    case "":
+    case null:
+    case undefined:
+      break;
+    case "stdout":
+      process.stdout.write(html);
+      break;
+    default: {
+      const newFilePath = path.isAbsolute(destination)
+        ? destination
+        : path.resolve(process.cwd(), destination);
+      await writeFile(newFilePath, html, "utf-8");
+    }
+  }
 }

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -3,7 +3,7 @@
  */
 const puppeteer = require("puppeteer");
 const path = require("path");
-const { mkdtemp, readFile, writeFile } = require("fs").promises;
+const { mkdtemp, readFile } = require("fs").promises;
 const { tmpdir } = require("os");
 
 const noop = () => {};
@@ -346,28 +346,4 @@ function createTimer(duration) {
   };
 }
 
-/**
- * @param {string | "stdout" | null | "" | undefined} destination
- * @param {string} html
- * @private Do not use this function directly outside ReSpec.
- */
-async function write(destination, html) {
-  switch (destination) {
-    case "":
-    case null:
-    case undefined:
-      break;
-    case "stdout":
-      process.stdout.write(html);
-      break;
-    default: {
-      const newFilePath = path.isAbsolute(destination)
-        ? destination
-        : path.resolve(process.cwd(), destination);
-      await writeFile(newFilePath, html, "utf-8");
-    }
-  }
-}
-
 exports.toHTML = toHTML;
-exports.write = write;


### PR DESCRIPTION
`write` is used only in CLI now (after-effect of https://github.com/w3c/respec/pull/3822).