### PR TITLE
fix(core/inlines): don't expand inlines in SVG

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -274,7 +274,7 @@ export function run(conf) {
 
   // PROCESSING
   // Don't gather text nodes for these:
-  const exclusions = ["#respec-ui", ".head", "pre"];
+  const exclusions = ["#respec-ui", ".head", "pre", "svg"];
   const txts = getTextNodes(document.body, exclusions, {
     wsNodes: false, // we don't want nodes with just whitespace
   });

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -124,6 +124,32 @@ describe("Core - Inlines", () => {
     expect(abbr.title).toBe("included abbr");
   });
 
+  it("excludes generating abbr elements in svg content", async () => {
+    const body = `
+      <section>
+        <h2>
+          <abbr title="expanded abbreviation">
+            EA
+          </abbr>
+        </h2>
+        <div id="test">
+          <svg version="1.1"
+            xmlns="http://www.w3.org/2000/svg">
+            <text>SVG EA</text>
+          </svg>
+          <p>HTML EA</p>
+        </div>
+      </section>
+    `;
+    const ops = makeStandardOps({}, body);
+    const doc = await makeRSDoc(ops);
+    const abbrs = doc.querySelectorAll("#test abbr");
+    expect(abbrs).toHaveSize(1);
+
+    const abbr = abbrs.item(0);
+    expect(abbr.title).toBe("expanded abbreviation");
+  });
+
   it("processes inline variable syntax", async () => {
     const body = `
       <section>


### PR DESCRIPTION
Tests that `<abbr>` element is not generated within an svg element.

Closes #4334.

Inspired by @sidvishnoi 's https://github.com/w3c/respec/issues/4334#issuecomment-1342616362

What I haven't thought much about, or checked:
* whether _other_ inline expansions than `<abbr>` are needed but also blocked by this change.

I _assume_ this will block all inline expansions, but I'm not sure if there is some need for others apart from `<abbr>`. Since all the tests pass, I think nobody ever created a test case for inlines being expanded in SVG. I guess if someone is relying on that behaviour some other change will be needed, to exclude specific inlines from specific subtrees.