### PR TITLE
No special treatment of plain anchors <a id="...">

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -67,7 +67,7 @@ export async function run(conf) {
 
   /** @type {NodeListOf<HTMLAnchorElement>} */
   const localAnchors = document.querySelectorAll(
-    "a[data-cite=''], a:not([href]):not([data-cite]):not(.logo):not(.externalDFN)"
+    "a[data-cite=''], a:not([href]):not([id]):not([data-cite]):not(.logo):not(.externalDFN)"
   );
   for (const anchor of localAnchors) {
     if (!anchor.dataset?.linkType && anchor.dataset?.xrefType) {


### PR DESCRIPTION
Ignore `<a id="...">` in addition to `<a href="...">` and some other anchor variants.

This style of anchors is the typical (only?) way to create a local link target in Markdown documents.

Fixes #4747 