### PR TITLE
fix(core/xref) : preserve the filename in URL

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -400,7 +400,10 @@ function addDataCite(elem, query, result, conf) {
   // but sometimes we get lucky and we get an absolute URL from xref
   // which we can then use in other places (e.g., data-cite.js)
   const url = new URL(uri, "https://partial");
-  const { pathname: citePath } = url;
+  let { pathname: citePath } = url;
+  // final resolution will be against the URL of the spec, which may end with
+  // a filename. That filename must be preserved if there's no specific path.
+  if (citePath === "/") citePath = "";
   const citeFrag = url.hash.slice(1);
   const dataset = { cite, citePath, citeFrag, type };
   if (forContext) dataset.linkFor = forContext[0];

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -1051,6 +1051,8 @@ describe("Core — xref", () => {
     const ops = makeStandardOps(null, body);
     const doc = await makeRSDoc(ops);
     const [specLink] = doc.querySelectorAll("#test a");
-    expect(specLink.href).toBe("https://w3c.github.io/reporting/network-reporting.html#endpoint-group");
+    expect(specLink.href).toBe(
+      "https://w3c.github.io/reporting/network-reporting.html#endpoint-group"
+    );
   });
 });

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -1043,4 +1043,14 @@ describe("Core — xref", () => {
     const test2 = doc.getElementById("test2");
     expect(test2.classList).toContain("respec-offending-element");
   });
+
+  it("preserves the filename in the URL of an external term", async () => {
+    const body = `<section id="test">
+      <p data-cite="network-reporting">[=endpoint group=]</p>
+    </section>`;
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+    const [specLink] = doc.querySelectorAll("#test a");
+    expect(specLink.href).toBe("https://w3c.github.io/reporting/network-reporting.html#endpoint-group");
+  });
 });


### PR DESCRIPTION
Fixes #4787.
The URL of the spec may end with a filename but the code assumed that it would always be a path, and thus that resolving `./` against the URL of the spec would be a no-op. The code now makes sure resolve the URL of the spec against an empty string when the xref search does not return a more specific path.