### PR TITLE
fix(core/pubsubhub): log errors from event handlers

### DIFF
--- a/src/core/pubsubhub.js
+++ b/src/core/pubsubhub.js
@@ -8,6 +8,7 @@
 export const name = "core/pubsubhub";
 
 import { expose } from "./expose-modules.js";
+import { showError } from "./utils.js";
 
 const subscriptions = new EventTarget();
 
@@ -36,7 +37,15 @@ export function pub(topic, detail) {
  *                               used for unsubscribing from messages.
  */
 export function sub(topic, cb, options = { once: false }) {
-  const listener = e => cb(e.detail);
+  /** @param {CustomEvent} ev */
+  const listener = async ev => {
+    try {
+      await cb(ev.detail);
+    } catch (error) {
+      const msg = `Error in handler for topic "${topic}": ${error.message}`;
+      showError(msg, `sub:${topic}`, { cause: error });
+    }
+  };
   subscriptions.addEventListener(topic, listener, options);
 }
 


### PR DESCRIPTION
Part of https://github.com/speced/respec/issues/4825

Instead of `rsError` being null (from global `window.onerror` listener), create rsError properly:
![image](https://github.com/user-attachments/assets/5ae8e422-fdcd-4427-b900-c2fefe2c0f46)
