### PR TITLE
fix(core/dfn-index): handle section number references with `.notoc`

### DIFF
--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -224,7 +224,9 @@ function getLocalTermSuffix(dfn, type, term = "") {
 function appendSectionNumbers() {
   const getSectionNumber = id => {
     const dfn = document.getElementById(id);
-    const sectionNumberEl = dfn.closest("section").querySelector(".secno");
+    const sectionNumberEl = dfn
+      .closest("section:not(.notoc)")
+      .querySelector(".secno");
     const secNum = `§${sectionNumberEl.textContent.trim()}`;
     return html`<span class="print-only">${secNum}</span>`;
   };


### PR DESCRIPTION
Fixes https://github.com/speced/respec/issues/4825