### PR TITLE
update TR intro text based on recent manual of style changes

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -8,7 +8,7 @@ const localizationStrings = {
     status_at_publication: html`This section describes the status of this
       document at the time of its publication. A list of current W3C
       publications and the latest revision of this technical report can be found
-      in the <a href="https://www.w3.org/TR/">W3C technical reports index</a> at
+      in the <a href="https://www.w3.org/TR/">W3C standards and drafts index</a> at
       https://www.w3.org/TR/.`,
   },
   ko: {
@@ -16,7 +16,7 @@ const localizationStrings = {
     status_at_publication: html`이 부분은 현재 문서의 발행 당시 상태에 대해
       기술합니다. W3C 발행 문서의 최신 목록 및 테크니컬 리포트 최신판을
       https://www.w3.org/TR/ 의
-      <a href="https://www.w3.org/TR/">W3C technical reports index</a> 에서
+      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a> 에서
       열람할 수 있습니다.`,
   },
   zh: {
@@ -30,7 +30,7 @@ const localizationStrings = {
   ja: {
     sotd: "この文書の位置付け",
     status_at_publication: html`この節には、公開時点でのこの文書の位置づけが記されている。現時点でのW3Cの発行文書とこのテクニカルレポートの最新版は、下記から参照できる。
-      <a href="https://www.w3.org/TR/">W3C technical reports index</a>
+      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>
       (https://www.w3.org/TR/)`,
   },
   nl: {
@@ -42,7 +42,7 @@ const localizationStrings = {
       documento al momento de su publicación. Una lista de las publicaciones
       actuales del W3C y la última revisión del presente informe técnico puede
       hallarse en http://www.w3.org/TR/
-      <a href="https://www.w3.org/TR/">el índice de informes técnicos</a> del
+      <a href="https://www.w3.org/TR/">el índice de normas y borradores</a> del
       W3C.`,
   },
   de: {
@@ -50,7 +50,7 @@ const localizationStrings = {
     status_at_publication: html`Dieser Abschnitt beschreibt den Status des
       Dokuments zum Zeitpunkt der Publikation. Eine Liste der aktuellen
       Publikatinen des W3C und die aktuellste Fassung dieser Spezifikation kann
-      im <a href="https://www.w3.org/TR/">W3C technical reports index</a> unter
+      im <a href="https://www.w3.org/TR/">W3C standards and drafts index</a> unter
       https://www.w3.org/TR/ abgerufen werden.`,
   },
 };


### PR DESCRIPTION
The [manual of style](https://w3c.github.io/guide/manual-of-style/#Status) was recently updated to replace 'technical reports index' with 'standards and drafts index'. That PR follows that requirement.

/cc @koalie @plehegar 