### PR TITLE
Handle undefined/null in error handler

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -330,6 +330,9 @@ function handleConsoleMessages(page, onError, onWarning) {
         });
       } else {
         // Ideally: `obj instanceof RsError` and `RsError instanceof Error`.
+        if (obj === null || obj === undefined) {
+          return JSON.stringify({message: obj});
+        }
         return JSON.stringify(obj);
       }
     }, handle);


### PR DESCRIPTION
Both `undefined` and `null` would crash Respec when attempting to report an error. This is the stacktrace that it would generate:

```
file:///home/runner/.npm/_npx/e8ed0ebe8657f7fb/node_modules/respec/tools/respec2html.js:62
    const message = colors.red(this._formatMarkdown(rsError.message));
                                                            ^

TypeError: Cannot read properties of null (reading 'message')
    at Logger.error (file:///home/runner/.npm/_npx/e8ed0ebe8657f7fb/node_modules/respec/tools/respec2html.js:62:61)
    at onError (file:///home/runner/.npm/_npx/e8ed0ebe8657f7fb/node_modules/respec/tools/respecDocWriter.js:55:13)
    at file:///home/runner/.npm/_npx/e8ed0ebe8657f7fb/node_modules/respec/tools/respecDocWriter.js:340:16
```

Instead, now it correctly reports the message:

```
[ERROR] null
```