### PR TITLE
fix(styles/respec): make bibref links distinguishable for a11y

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -59,7 +59,7 @@ a[href].respec-offending-element {
 }
 
 cite .bibref {
-  font-style: normal;
+  font-style: italic;
 }
 
 a[href].orcid {


### PR DESCRIPTION
Axe reports that bibliography references aren't accessible, as they are links but don't appear as such:

```
 • Error: Links must be distinguishable without relying on color (https://dequeuniversity.com/rules/axe/4.8/link-in-text-block?application=axeAPI)
   ├── link-in-text-block
   ├── #glossary > dl > dd:nth-child(8) > cite > a
   └── <a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">rfc3986</a>
```

Rather than using an underline (since that would clash with the block notation of referencing), adding an italic text does make it appear visually distinct.