### PR TITLE
Report all `console.error` arguments

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -338,7 +338,7 @@ function handleConsoleMessages(page, onError, onWarning) {
   page.on("console", async message => {
     const args = await Promise.all(message.args().map(stringifyJSHandle));
     const msgText = message.text();
-    const text = args.filter(msg => msg !== "undefined")[0] || "";
+    const text = args.filter(msg => msg !== "undefined") || [{}];
     const type = message.type();
     if (
       (type === "error" || type === "warning" || type === "warn") &&
@@ -351,12 +351,16 @@ function handleConsoleMessages(page, onError, onWarning) {
       // https://github.com/GoogleChrome/puppeteer/issues/1939
       return;
     }
-    switch (type) {
-      case "error":
-        return onError(JSON.parse(text));
-      case "warn":
-      case "warning":
-        return onWarning(JSON.parse(text));
+    for (const textParts of text) {
+      switch (type) {
+        case "error":
+          onError(JSON.parse(textParts));
+          break;
+        case "warn":
+        case "warning":
+          onWarning(JSON.parse(textParts));
+          break;
+      }
     }
   });
 }


### PR DESCRIPTION
While attempting to debug an issue with the `respec-mermaid` plugin, we discovered that the plugin logs multiple messages in the same `console.error` call:

```
console.error('respec-mermaid error: Failed to generate figure.',
  e, mermaidSource);
```

Unfortunately only the first message would appear in the console logs when running Respec. That's because it would get the `[0]` index of the args array and would report that as text.

Instead of only reporting the first argument, instead loop over all argument text parts and report them individually on the console. We can then use this to figure out why our mermaid figures are not correctly rendering on CI (they are fine on local).