### PR TITLE
fix(lint/wpt-tests-exist): ignore `?` when finding tests

### DIFF
--- a/src/core/linter-rules/wpt-tests-exist.js
+++ b/src/core/linter-rules/wpt-tests-exist.js
@@ -33,7 +33,7 @@ export async function run(conf) {
   for (const elem of testables) {
     elem.dataset.tests
       .split(/,/gm)
-      .map(test => test.trim().split("#")[0])
+      .map(test => test.trim().split(/\?|#/)[0])
       .filter(test => test && !filesInWPT.has(test))
       .map(missingTest => {
         showWarning(`${l10n.msg} \`${missingTest}\`.`, name, {


### PR DESCRIPTION
Fixes: https://github.com/speced/respec/issues/4966