### PR TITLE
fix(w3c/sotd): remove draft wording for Notes

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -267,6 +267,7 @@ function renderNotRec(conf) {
         ${getWgHTML(conf)}, but is not endorsed by
         <abbr title="World Wide Web Consortium">W3C</abbr> itself nor its
         Members.`;
+      updatePolicy = "";
       break;
   }
   return html`<p>${endorsement} ${statusExplanation}</p>


### PR DESCRIPTION
As per https://github.com/w3c/specberus/issues/1957, and after some more discussion with @deniak ,W3C Working Group NOtes should not include the sentence "This is a draft document and may be updated, replaced, or obsoleted by other documents at any time. It is inappropriate to cite this document as other than work in progress".
I think respec is including this by default in any nonREC documents, but Notes should be an exception here.
