### PR TITLE
fix(w3c/sotd): update SotD requirements

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -48,8 +48,7 @@ const localizationStrings = {
     status_at_publication: html`Dieser Abschnitt beschreibt den Status des
       Dokuments zum Zeitpunkt der Publikation. Eine Liste der aktuellen
       Publikatinen des W3C und die aktuellste Fassung dieser Spezifikation kann
-      im
-      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.`,
+      im <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.`,
   },
 };
 

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -9,14 +9,12 @@ const localizationStrings = {
       document at the time of its publication. A list of current W3C
       publications and the latest revision of this technical report can be found
       in the
-      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a> at
-      https://www.w3.org/TR/.`,
+      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.`,
   },
   ko: {
     sotd: "현재 문서의 상태",
     status_at_publication: html`이 부분은 현재 문서의 발행 당시 상태에 대해
-      기술합니다. W3C 발행 문서의 최신 목록 및 테크니컬 리포트 최신판을
-      https://www.w3.org/TR/ 의
+      기술합니다. W3C 발행 문서의 최신 목록 및 테크니컬 리포트 최신판의
       <a href="https://www.w3.org/TR/">W3C standards and drafts index</a> 에서
       열람할 수 있습니다.`,
   },
@@ -31,8 +29,7 @@ const localizationStrings = {
   ja: {
     sotd: "この文書の位置付け",
     status_at_publication: html`この節には、公開時点でのこの文書の位置づけが記されている。現時点でのW3Cの発行文書とこのテクニカルレポートの最新版は、下記から参照できる。
-      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>
-      (https://www.w3.org/TR/)`,
+      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>`,
   },
   nl: {
     sotd: "Status van dit document",
@@ -42,7 +39,7 @@ const localizationStrings = {
     status_at_publication: html`Esta sección describe el estado del presente
       documento al momento de su publicación. Una lista de las publicaciones
       actuales del W3C y la última revisión del presente informe técnico puede
-      hallarse en http://www.w3.org/TR/
+      hallarse en
       <a href="https://www.w3.org/TR/">el índice de normas y borradores</a> del
       W3C.`,
   },
@@ -52,8 +49,7 @@ const localizationStrings = {
       Dokuments zum Zeitpunkt der Publikation. Eine Liste der aktuellen
       Publikatinen des W3C und die aktuellste Fassung dieser Spezifikation kann
       im
-      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a> unter
-      https://www.w3.org/TR/ abgerufen werden.`,
+      <a href="https://www.w3.org/TR/">W3C standards and drafts index</a>.`,
   },
 };
 
@@ -158,7 +154,7 @@ function renderNotRec(conf) {
   let updatePolicy = html`<p>
     This is a draft document and may be updated, replaced, or obsoleted by other
     documents at any time. It is inappropriate to cite this document as other
-    than work in progress.
+    than a work in progress.
     ${updatableRec
       ? html`Future updates to this specification may incorporate
           <a href="${processLink}#allow-new-features">new features</a>.`
@@ -388,7 +384,7 @@ function renderDeliverer(conf) {
             ? "each group; these pages also include"
             : "the group; that page also includes"}
           instructions for disclosing a patent. An individual who has actual
-          knowledge of a patent which the individual believes contains
+          knowledge of a patent that the individual believes contains
           <a href="${patentPolicyURL}#def-essential">Essential Claim(s)</a>
           must disclose the information in accordance with
           <a href="${patentPolicyURL}#sec-Disclosure"


### PR DESCRIPTION
There's an open PR on pubrules to fix some errors with the W3C SotD (https://github.com/w3c/specberus/pull/1972).
That PR updates respec to follow the new requirements.

Note that we need to deploy it shortly after the new version of pubrules is released, hence the draft PR.