### PR TITLE
fix(w3c/headers): allow forcing `/TR` namespace for TAG/AB

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -667,9 +667,10 @@ function derivePubSpace(conf) {
 
   if (
     (conf.group === "tag" || conf.group === "ab") &&
-    conf.canonicalURI === "TR") {
-      return `/TR`
-    }
+    conf.canonicalURI === "TR"
+  ) {
+    return `/TR`;
+  }
 
   return "";
 }


### PR DESCRIPTION
Fixes https://github.com/speced/respec/issues/5084
The solution rely on using canonicalURI = "TR" in the ReSpec config.
