### PR TITLE
feat(core/rs-changelog): let `repo` attr override `github` config

### DIFF
--- a/src/core/custom-elements/rs-changelog.js
+++ b/src/core/custom-elements/rs-changelog.js
@@ -42,7 +42,7 @@ export const element = class ChangelogElement extends HTMLElement {
       <ul>
       ${{
         any: fetchCommits(from, to, filter, repo, path)
-          .then(commits => toHTML(commits, repo))
+          .then(commits => toHTML(commits))
           .catch(error =>
             showError(error.message, name, { elements: [this], cause: error })
           )
@@ -64,9 +64,8 @@ async function fetchCommits(from, to, filter, repo, path) {
     if (!gh) {
       throw new Error("`respecConfig.github` is not set");
     }
-    const apiBase = gh.apiBase;
     const fullName = repo || gh.fullName;
-    const url = new URL("commits", `${apiBase}/${fullName}/`);
+    const url = new URL("commits", `${gh.apiBase}/${fullName}/`);
     url.searchParams.set("from", from);
     url.searchParams.set("to", to);
     if (path) {
@@ -91,18 +90,8 @@ async function fetchCommits(from, to, filter, repo, path) {
   return commits;
 }
 
-async function toHTML(commits, repo) {
-  let repoURL;
-  
-  if (repo) {
-    // Construct repoURL from repo (e.g., "owner/repo" -> "https://github.com/owner/repo/")
-    repoURL = `https://github.com/${repo}/`;
-  } else {
-    // Use the default repoURL from respecConfig.github
-    const gh = await github;
-    repoURL = gh.repoURL;
-  }
-  
+async function toHTML(commits) {
+  const { repoURL } = await github;
   return commits.map(commit => {
     const [message, prNumber = null] = commit.message.split(/\(#(\d+)\)/, 2);
     const commitURL = `${repoURL}commit/${commit.hash}`;

--- a/src/core/custom-elements/rs-changelog.js
+++ b/src/core/custom-elements/rs-changelog.js
@@ -42,7 +42,7 @@ export const element = class ChangelogElement extends HTMLElement {
       <ul>
       ${{
         any: fetchCommits(from, to, filter, repo, path)
-          .then(commits => toHTML(commits))
+          .then(commits => toHTML(commits, repo))
           .catch(error =>
             showError(error.message, name, { elements: [this], cause: error })
           )
@@ -90,8 +90,11 @@ async function fetchCommits(from, to, filter, repo, path) {
   return commits;
 }
 
-async function toHTML(commits) {
-  const { repoURL } = await github;
+async function toHTML(commits, repo) {
+  const gh = await github;
+  const repoURL = repo
+    ? `https://github.com/${repo}/`
+    : gh.repoURL;
   return commits.map(commit => {
     const [message, prNumber = null] = commit.message.split(/\(#(\d+)\)/, 2);
     const commitURL = `${repoURL}commit/${commit.hash}`;

--- a/src/core/custom-elements/rs-changelog.js
+++ b/src/core/custom-elements/rs-changelog.js
@@ -60,22 +60,12 @@ async function fetchCommits(from, to, filter, repo, path) {
   /** @type {Commit[]} */
   let commits;
   try {
-    let apiBase, fullName;
-    
-    if (repo) {
-      // Use repo provided as attribute (e.g., "owner/repo")
-      apiBase = "https://respec.org/github";
-      fullName = repo;
-    } else {
-      // Fall back to respecConfig.github
-      const gh = await github;
-      if (!gh) {
-        throw new Error("`respecConfig.github` is not set");
-      }
-      apiBase = gh.apiBase;
-      fullName = gh.fullName;
+    const gh = await github;
+    if (!gh) {
+      throw new Error("`respecConfig.github` is not set");
     }
-    
+    const apiBase = gh.apiBase;
+    const fullName = repo || gh.fullName;
     const url = new URL("commits", `${apiBase}/${fullName}/`);
     url.searchParams.set("from", from);
     url.searchParams.set("to", to);

--- a/src/core/custom-elements/rs-changelog.js
+++ b/src/core/custom-elements/rs-changelog.js
@@ -92,9 +92,7 @@ async function fetchCommits(from, to, filter, repo, path) {
 
 async function toHTML(commits, repo) {
   const gh = await github;
-  const repoURL = repo
-    ? `https://github.com/${repo}/`
-    : gh.repoURL;
+  const repoURL = repo ? `https://github.com/${repo}/` : gh.repoURL;
   return commits.map(commit => {
     const [message, prNumber = null] = commit.message.split(/\(#(\d+)\)/, 2);
     const commitURL = `${repoURL}commit/${commit.hash}`;

--- a/tests/data/github/corp/repo/commits
+++ b/tests/data/github/corp/repo/commits
@@ -1,0 +1,10 @@
+[
+  {
+    "hash": "80aad0a",
+    "message": "Editorial: Add privacy notice regarding <var> usage (#869)"
+  },
+  {
+    "hash": "276f4ba",
+    "message": "fix: ReSpec fixes"
+  }
+]

--- a/tests/spec/core/custom-elements/rs-changelog-spec.js
+++ b/tests/spec/core/custom-elements/rs-changelog-spec.js
@@ -55,11 +55,13 @@ describe("Core - Custom Elements - <rs-changelog>", () => {
     const doc = await makeRSDoc(ops);
 
     const commits = doc.querySelectorAll("rs-changelog li");
-    expect(commits).toHaveSize(8);
+    expect(commits).toHaveSize(2);
     const firstCommit = commits[0];
     // Verify links point to the custom repo, not the config repo
     const links = firstCommit.querySelectorAll("a");
-    expect(links).toHaveSize(1);
-    expect(links[0].href).toBe("https://github.com/org/corp/commit/80aad0a");
+    expect(links).toHaveSize(2);
+    const [commitLink, prLink] = links;
+    expect(commitLink.href).toBe("https://github.com/corp/repo/commit/80aad0a");
+    expect(prLink.href).toBe("https://github.com/corp/repo/pull/869");
   });
 });

--- a/tests/spec/core/custom-elements/rs-changelog-spec.js
+++ b/tests/spec/core/custom-elements/rs-changelog-spec.js
@@ -50,7 +50,7 @@ describe("Core - Custom Elements - <rs-changelog>", () => {
   });
 
   it("uses custom repo parameter to override config", async () => {
-    const body = `<rs-changelog from="CR2" to="HEAD" repo="org/repo"></rs-changelog>`;
+    const body = `<rs-changelog from="CR2" to="HEAD" repo="corp/repo"></rs-changelog>`;
     const ops = makeStandardOps(conf, body);
     const doc = await makeRSDoc(ops);
 

--- a/tests/spec/core/custom-elements/rs-changelog-spec.js
+++ b/tests/spec/core/custom-elements/rs-changelog-spec.js
@@ -50,7 +50,7 @@ describe("Core - Custom Elements - <rs-changelog>", () => {
   });
 
   it("uses custom repo parameter to override config", async () => {
-    const body = `<rs-changelog from="CR2" to="HEAD" repo="custom/other-repo"></rs-changelog>`;
+    const body = `<rs-changelog from="CR2" to="HEAD" repo="org/repo"></rs-changelog>`;
     const ops = makeStandardOps(conf, body);
     const doc = await makeRSDoc(ops);
 
@@ -60,6 +60,6 @@ describe("Core - Custom Elements - <rs-changelog>", () => {
     // Verify links point to the custom repo, not the config repo
     const links = firstCommit.querySelectorAll("a");
     expect(links).toHaveSize(1);
-    expect(links[0].href).toBe("https://github.com/custom/other-repo/commit/80aad0a");
+    expect(links[0].href).toBe("https://github.com/org/repo/commit/80aad0a");
   });
 });

--- a/tests/spec/core/custom-elements/rs-changelog-spec.js
+++ b/tests/spec/core/custom-elements/rs-changelog-spec.js
@@ -48,4 +48,18 @@ describe("Core - Custom Elements - <rs-changelog>", () => {
     expect(commitLink.href).toBe("https://github.com/org/repo/commit/276f4ba");
     expect(prLink.href).toBe("https://github.com/org/repo/pull/869");
   });
+
+  it("uses custom repo parameter to override config", async () => {
+    const body = `<rs-changelog from="CR2" to="HEAD" repo="custom/other-repo"></rs-changelog>`;
+    const ops = makeStandardOps(conf, body);
+    const doc = await makeRSDoc(ops);
+
+    const commits = doc.querySelectorAll("rs-changelog li");
+    expect(commits).toHaveSize(8);
+    const firstCommit = commits[0];
+    // Verify links point to the custom repo, not the config repo
+    const links = firstCommit.querySelectorAll("a");
+    expect(links).toHaveSize(1);
+    expect(links[0].href).toBe("https://github.com/custom/other-repo/commit/80aad0a");
+  });
 });

--- a/tests/spec/core/custom-elements/rs-changelog-spec.js
+++ b/tests/spec/core/custom-elements/rs-changelog-spec.js
@@ -60,6 +60,6 @@ describe("Core - Custom Elements - <rs-changelog>", () => {
     // Verify links point to the custom repo, not the config repo
     const links = firstCommit.querySelectorAll("a");
     expect(links).toHaveSize(1);
-    expect(links[0].href).toBe("https://github.com/org/repo/commit/80aad0a");
+    expect(links[0].href).toBe("https://github.com/org/corp/commit/80aad0a");
   });
 });


### PR DESCRIPTION
@sidvishnoi 

This is one more that the ARIA monorepo setup would greatly benefit from.

It enables a new `repo` parameter  to be used with the `rs-changelog` custom element. This is for monorepos which still keep child repos in the respecConfig (mainly for issue base, editor draft, and other generated properties), but are using a single repo to generate all specs. For child specs we need to specify that they want to pull the commit history from the monorepo instead of from the child repo.
