### PR TITLE
fix(respec2html): update Renderer for marked v16 token-based API

### DIFF
--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -13,25 +13,28 @@ import { toHTML } from "./respecDocWriter.js";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 class Renderer extends marked.Renderer {
-  strong(text) {
-    return colors.bold(text);
+  strong(token) {
+    return colors.bold(this.parser.parseInline(token.tokens));
   }
-  em(text) {
-    return colors.italic(text);
+  em(token) {
+    return colors.italic(this.parser.parseInline(token.tokens));
   }
-  codespan(text) {
-    return colors.underline(unescape(text));
+  codespan(token) {
+    return colors.underline(unescape(token.text));
   }
-  paragraph(text) {
-    return unescape(text);
+  paragraph(token) {
+    return unescape(this.parser.parseInline(token.tokens));
   }
-  link(href, _title, text) {
-    return `[${text}](${colors.blue.dim.underline(href)})`;
+  link(token) {
+    const text = this.parser.parseInline(token.tokens);
+    return `[${text}](${colors.blue.dim.underline(token.href)})`;
   }
-  list(body, _orderered) {
+  list(token) {
+    const body = token.items.map(item => this.listitem(item)).join("");
     return `\n${body}`;
   }
-  listitem(text) {
+  listitem(token) {
+    const text = this.parser.parseInline(token.tokens);
     return `* ${text}\n`;
   }
 }
@@ -85,7 +88,7 @@ class Logger {
 
   _formatMarkdown(str) {
     if (typeof str !== "string") return str;
-    return marked(str, { smartypants: true, renderer: new Renderer() });
+    return marked(str, { renderer: new Renderer() });
   }
 
   /** @param {import("./respecDocWriter").ReSpecError} rsError */


### PR DESCRIPTION
## Summary

- marked v16 changed the `Renderer` API: methods now receive **token objects** instead of pre-rendered strings, but `respec2html.js` was still using the v12 API
- This caused a crash (`str.replace is not a function`) any time ReSpec reported an error or warning during `respec2html` runs
- The bug was introduced by #5129 (marked 12 → 16 upgrade) but not caught at the time because the `respec2html` error-rendering path only triggers on actual document errors

## Changes

- All renderer methods updated to accept token objects and use `this.parser.parseInline(token.tokens)` for child content rendering
- `link()` updated to use `token.href` and `token.tokens` instead of positional arguments (v16 changed the signature)
- `list()` updated to iterate `token.items` instead of receiving a pre-rendered body string
- Removed `smartypants` option (removed from marked in v13+, silently ignored since then)

## How to reproduce the bug

Any spec that produces a ReSpec error or warning will crash `respec2html` with:
```
TypeError: str.replace is not a function
  at unescape (respec2html.js:334)
  at Renderer.paragraph (respec2html.js:25)
  at Logger._formatMarkdown (respec2html.js:87)
```

The crash happens because `Logger._formatMarkdown` formats error messages using `marked`, which now passes token objects to `Renderer.paragraph()` instead of strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)