### PR TITLE
fix: Make target background of references accessible in dark mode

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -60,7 +60,11 @@ a[href].respec-offending-element {
 
 @media (prefers-color-scheme: dark) {
   #references :target {
-    background: rgb(255 255 255 / 30%);
+    background: color-mix(
+      in srgb,
+      var(--borderedblock-bg) 70%,
+      transparent
+    );
   }
 }
 

--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -58,6 +58,12 @@ a[href].respec-offending-element {
   animation: pop 0.4s ease-in-out 0s 1;
 }
 
+@media (prefers-color-scheme: dark) {
+  #references :target {
+    background: rgb(255 255 255 / 30%);
+  }
+}
+
 cite .bibref {
   font-style: italic;
 }


### PR DESCRIPTION
Reported in our documents that the light blueish background for targeted references is not accessible:
https://github.com/Logius-standaarden/publicatie/issues/57

Instead, we can use the same styling as we have for `var(--borderedblock-bg)` (which are used for examples), except make its opacity higher (5% to 30%).