### PR TITLE
fix(w3c/sotd): Adjust pluralization of "Working Group" for CRD/CRYD

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -197,7 +197,7 @@ function renderNotRec(conf) {
     case "CRD":
       statusExplanation = html`A Candidate Recommendation Draft integrates
       changes from the previous Candidate Recommendation that the Working
-      Group${Array.isArray(conf.wg) ? "s intend" : " intends"} to include in a
+      Group${conf.multipleWGs ? "s intend" : " intends"} to include in a
       subsequent Candidate Recommendation Snapshot.`;
       if (conf.pubMode === "LS") {
         updatePolicy = lsUpdatePolicy;
@@ -206,7 +206,7 @@ function renderNotRec(conf) {
     case "CRYD":
       statusExplanation = html`A Candidate Registry Draft integrates changes
       from the previous Candidate Registry Snapshot that the Working
-      Group${Array.isArray(conf.wg) ? "s intend" : " intends"} to include in a
+      Group${conf.multipleWGs ? "s intend" : " intends"} to include in a
       subsequent Candidate Registry Snapshot.`;
       if (conf.pubMode === "LS") {
         updatePolicy = lsUpdatePolicy;

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -196,16 +196,18 @@ function renderNotRec(conf) {
       break;
     case "CRD":
       statusExplanation = html`A Candidate Recommendation Draft integrates
-      changes from the previous Candidate Recommendation that the Working Group
-      intends to include in a subsequent Candidate Recommendation Snapshot.`;
+      changes from the previous Candidate Recommendation that the Working Group${
+        Array.isArray(conf.wg) ? "s intend" : " intends"
+      } to include in a subsequent Candidate Recommendation Snapshot.`;
       if (conf.pubMode === "LS") {
         updatePolicy = lsUpdatePolicy;
       }
       break;
     case "CRYD":
       statusExplanation = html`A Candidate Registry Draft integrates changes
-      from the previous Candidate Registry Snapshot that the Working Group
-      intends to include in a subsequent Candidate Registry Snapshot.`;
+      from the previous Candidate Registry Snapshot that the Working Group${
+        Array.isArray(conf.wg) ? "s intend" : " intends"
+      } to include in a subsequent Candidate Registry Snapshot.`;
       if (conf.pubMode === "LS") {
         updatePolicy = lsUpdatePolicy;
       }

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -196,18 +196,18 @@ function renderNotRec(conf) {
       break;
     case "CRD":
       statusExplanation = html`A Candidate Recommendation Draft integrates
-      changes from the previous Candidate Recommendation that the Working Group${
-        Array.isArray(conf.wg) ? "s intend" : " intends"
-      } to include in a subsequent Candidate Recommendation Snapshot.`;
+      changes from the previous Candidate Recommendation that the Working
+      Group${Array.isArray(conf.wg) ? "s intend" : " intends"} to include in a
+      subsequent Candidate Recommendation Snapshot.`;
       if (conf.pubMode === "LS") {
         updatePolicy = lsUpdatePolicy;
       }
       break;
     case "CRYD":
       statusExplanation = html`A Candidate Registry Draft integrates changes
-      from the previous Candidate Registry Snapshot that the Working Group${
-        Array.isArray(conf.wg) ? "s intend" : " intends"
-      } to include in a subsequent Candidate Registry Snapshot.`;
+      from the previous Candidate Registry Snapshot that the Working
+      Group${Array.isArray(conf.wg) ? "s intend" : " intends"} to include in a
+      subsequent Candidate Registry Snapshot.`;
       if (conf.pubMode === "LS") {
         updatePolicy = lsUpdatePolicy;
       }

--- a/tests/spec/w3c/group-spec.js
+++ b/tests/spec/w3c/group-spec.js
@@ -37,7 +37,7 @@ describe("W3C — Group", () => {
     ]);
   });
 
-  it("when a multiple groups are specified, it pluralizes the groups", async () => {
+  it("when multiple groups are specified, it pluralizes the groups", async () => {
     const ops = makeStandardOps({
       group: ["payments", "webapps"],
       specStatus: "NOTE",
@@ -48,6 +48,28 @@ describe("W3C — Group", () => {
       "by the Web Payments Working Group and the Web Applications Working Group as a Group Note using the Note track"
     );
   });
+
+  for (const specStatus of ["CRD", "CRYD"]) {
+    it(`when one group is specified in a ${specStatus}, "Working Group" is singular`, async () => {
+      const ops = makeStandardOps({
+        group: "payments",
+        specStatus,
+      });
+      const doc = await makeRSDoc(ops);
+      const sotd = doc.getElementById("sotd").textContent.replace(/\s+/g, " ");
+      expect(sotd).toContain("that the Working Group intends to include in");
+    });
+
+    it(`when multiple groups are specified in a ${specStatus}, "Working Groups" are plural`, async () => {
+      const ops = makeStandardOps({
+        group: ["payments", "webapps"],
+        specStatus,
+      });
+      const doc = await makeRSDoc(ops);
+      const sotd = doc.getElementById("sotd").textContent.replace(/\s+/g, " ");
+      expect(sotd).toContain("that the Working Groups intend to include in");
+    });
+  }
 
   it("overrides superseded options", async () => {
     const inputConf = { group: "payments", wg: "foo", wgId: "1234" };

--- a/tests/spec/w3c/group-spec.js
+++ b/tests/spec/w3c/group-spec.js
@@ -50,7 +50,7 @@ describe("W3C — Group", () => {
   });
 
   for (const specStatus of ["CRD", "CRYD"]) {
-    it(`when one group is specified in a ${specStatus}, "Working Group" is singular`, async () => {
+    it(`${specStatus}: writes "Working Group intends" for a single group`, async () => {
       const ops = makeStandardOps({
         group: "payments",
         specStatus,
@@ -60,7 +60,17 @@ describe("W3C — Group", () => {
       expect(sotd).toContain("that the Working Group intends to include in");
     });
 
-    it(`when multiple groups are specified in a ${specStatus}, "Working Groups" are plural`, async () => {
+    it(`${specStatus}: writes "Working Group intends" for a single group in an array`, async () => {
+      const ops = makeStandardOps({
+        group: ["payments"],
+        specStatus,
+      });
+      const doc = await makeRSDoc(ops);
+      const sotd = doc.getElementById("sotd").textContent.replace(/\s+/g, " ");
+      expect(sotd).toContain("that the Working Group intends to include in");
+    });
+
+    it(`${specStatus}: writes "Working Groups intend" for multiple groups`, async () => {
       const ops = makeStandardOps({
         group: ["payments", "webapps"],
         specStatus,


### PR DESCRIPTION
Fixes #5164.

This adds a condition to the value of `statusExplanation` dependent on whether the document lists a single WG or multiple WGs, so that "Working Group" is properly pluralized in the latter case.

This logic is in line with [what pubrules checks for](https://github.com/w3c/specberus/blob/cb1d5575/lib/rules/sotd/stability.js#L38).