### PR TITLE
fix: remove cookie override that broke engine.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
       "vnu-jar"
     ],
     "overrides": {
-      "cookie": ">=0.7.0",
       "flatted": ">=3.4.2",
       "jasmine>glob": ">=10.5.0",
       "lodash": ">=4.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  cookie: '>=0.7.0'
   flatted: '>=3.4.2'
   jasmine>glob: '>=10.5.0'
   lodash: '>=4.18.0'
@@ -863,9 +862,9 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie@0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
 
   cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -3342,7 +3341,7 @@ snapshots:
 
   content-type@1.0.5: {}
 
-  cookie@1.1.1: {}
+  cookie@0.4.2: {}
 
   cors@2.8.5:
     dependencies:
@@ -3504,7 +3503,7 @@ snapshots:
       '@types/node': 24.2.0
       accepts: 1.3.8
       base64id: 2.0.0
-      cookie: 1.1.1
+      cookie: 0.4.2
       cors: 2.8.5
       debug: 4.3.7
       engine.io-parser: 5.2.1


### PR DESCRIPTION
## Problem

The `"cookie": ">=0.7.0"` pnpm override added in #5163 resolved to `cookie@1.1.1` — a major version bump. `engine.io@6.5.4` (karma's browser-server transport) requires `cookie ~0.4.1`, so the API break caused all Chrome browser tests to fail on main.

## Fix

Remove the `cookie` override. `cookie@0.4.2` returns, which is compatible with `engine.io`.

The CVE this was targeting (cookie < 0.7.0) only affects this dev-only testing stack — the risk is low. A proper fix requires upgrading karma to a version that pulls in `engine.io@6.6+`, which itself uses `cookie ^0.7.0`. That's a follow-up.

## Refs

Broke by: #5163