### PR TITLE
Add configurable MCP support for ReSpec report workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:24-bookworm-slim
+
+ENV PUPPETEER_CACHE_DIR=/root/.cache/puppeteer
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  fonts-liberation \
+  libasound2 \
+  libatk-bridge2.0-0 \
+  libatk1.0-0 \
+  libcups2 \
+  libdbus-1-3 \
+  libdrm2 \
+  libgbm1 \
+  libglib2.0-0 \
+  libgtk-3-0 \
+  libnspr4 \
+  libnss3 \
+  libu2f-udev \
+  libx11-6 \
+  libx11-xcb1 \
+  libxcb1 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxext6 \
+  libxfixes3 \
+  libxkbcommon0 \
+  libxrandr2 \
+  xdg-utils \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . .
+
+RUN corepack enable \
+  && pnpm install --frozen-lockfile
+
+ENTRYPOINT ["node", "tools/respec-mcp.js", "--repo-root", "/workspace"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ if you think something is broken, [file a bug](https://github.com/speced/respec/
 problems encountered with ReSpec, or on why it may be failing to produce pubrules-compliant
 content.
 
+## MCP server
+
+ReSpec now ships a stdio MCP companion entrypoint, `respec-mcp`, for AI-assisted
+spec authoring and validation. The MCP server discovers repo-local configuration from
+`respec-mcp.config.json` and `respec-mcp/profiles/*.json`, so Community Groups and
+other spec repos can add local policy without forking ReSpec.
+
+Use:
+
+```bash
+respec-mcp --repo-root /path/to/spec-repo
+```
+
+Or via Docker:
+
+```bash
+docker build -t respec-mcp:local .
+docker run --rm -i -v "$PWD":/workspace -w /workspace respec-mcp:local
+```
+
+See [docs/MCP.md](docs/MCP.md) for the config contract, tool list, and AI client examples.
+For LLM-assisted authoring guidance, including W3C/Community Group report patterns,
+see [docs/MCP_LLM_AUTHORING_GUIDE.md](docs/MCP_LLM_AUTHORING_GUIDE.md).
+
 ## Bibliographical references
 
 Bibliographical references have been moved out of ReSpec. You want to use

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,107 @@
+# ReSpec MCP
+
+## Summary
+
+`respec-mcp` is a stdio MCP server that wraps ReSpec's existing rendering API and
+adds repo-local profile discovery. The goal is to let specification repos keep their
+own policy, templates, and build paths while reusing one upstream MCP runtime.
+
+LLM operators should also read [MCP_LLM_AUTHORING_GUIDE.md](MCP_LLM_AUTHORING_GUIDE.md)
+before drafting or revising W3C/Community Group reports.
+
+## Repo-local configuration
+
+Each consuming repo can provide:
+
+- `respec-mcp.config.json`
+- `respec-mcp/profiles/*.json`
+
+Minimal config example:
+
+```json
+{
+  "default_profile": "example-cg",
+  "profile_directory": "respec-mcp/profiles",
+  "source_root": "reports/source",
+  "build_root": "reports/build"
+}
+```
+
+Minimal profile example:
+
+```json
+{
+  "profile_id": "example-cg",
+  "allowed_statuses": ["CG-DRAFT", "CG-FINAL"],
+  "default_status": "CG-DRAFT",
+  "repo_metadata_source": "w3c.json",
+  "status_templates": {
+    "CG-DRAFT": "respec-mcp/templates/cg-draft.html",
+    "CG-FINAL": "respec-mcp/templates/cg-final.html"
+  },
+  "required_sections": ["Abstract", "Introduction"],
+  "required_links": ["https://www.w3.org/community/example/"],
+  "forbidden_phrases": ["W3C Recommendation"]
+}
+```
+
+## Tools
+
+- `respec_list_profiles`
+- `respec_scaffold`
+- `respec_build`
+- `respec_validate`
+- `respec_preflight`
+
+All tools accept `repo_root` and may accept `profile`, `status`, `source`, `output`,
+and `overrides` depending on the operation.
+
+## Local execution
+
+```bash
+node tools/respec-mcp.js --repo-root /path/to/spec-repo
+```
+
+## Docker execution
+
+```bash
+docker build -t respec-mcp:local .
+docker run --rm -i -v /path/to/spec-repo:/workspace -w /workspace respec-mcp:local
+```
+
+## AI client usage
+
+Point the client to the stdio command and set the repo root at process start or per
+tool call.
+
+Authoring discipline matters as much as rendering. For W3C/CG reports, clients
+should load the repo profile plus the guidance in
+[MCP_LLM_AUTHORING_GUIDE.md](MCP_LLM_AUTHORING_GUIDE.md) before using
+`respec_scaffold`, `respec_validate`, `respec_preflight`, or `respec_build`.
+
+Local:
+
+```json
+{
+  "command": "node",
+  "args": ["tools/respec-mcp.js", "--repo-root", "/path/to/spec-repo"]
+}
+```
+
+Docker:
+
+```json
+{
+  "command": "docker",
+  "args": [
+    "run",
+    "--rm",
+    "-i",
+    "-v",
+    "/path/to/spec-repo:/workspace",
+    "-w",
+    "/workspace",
+    "respec-mcp:local"
+  ]
+}
+```

--- a/docs/MCP_LLM_AUTHORING_GUIDE.md
+++ b/docs/MCP_LLM_AUTHORING_GUIDE.md
@@ -1,0 +1,230 @@
+# ReSpec MCP LLM Authoring Guide
+
+## Purpose
+
+This guide is for LLMs and AI-assisted editors operating the `respec-mcp`
+tools. It is intended to make the MCP useful for actual W3C-style document
+authoring, not just HTML rendering.
+
+Use this guide when drafting, revising, validating, or preflighting Community
+Group reports, final reports, and standards-transition documents.
+
+## Read First
+
+Before generating report content, load these sources:
+
+1. The target repo's `respec-mcp.config.json`
+2. The target repo profile JSON under `respec-mcp/profiles/`
+3. W3C Community Group report requirements:
+   - <https://www.w3.org/community/reports/reqs/>
+4. If the document is meant to support later standards work:
+   - <https://www.w3.org/guide/standards-track/>
+   - <https://www.w3.org/guide/process/cg-transition.html>
+   - <https://www.w3.org/community/about/faq/#how-do-community-groups-make-it-easier-to-move-to-the-standards-track>
+
+Do not start from generic “spec writing” habits alone. Use the repo profile and
+the W3C requirements as the controlling constraints.
+
+## Document Type Discipline
+
+Choose the document type before drafting:
+
+- `CG-DRAFT`: active Community Group draft report.
+- `CG-FINAL`: stabilized Community Group final report.
+- Transition/support report: a CG draft report whose purpose is to prepare
+  adoption by a Working Group or another standards-track venue.
+- Explainer: a problem-and-proposal document for design discussion.
+
+Do not confuse these types.
+
+In particular:
+
+- A Community Group report is **not** a W3C Standard.
+- A transition report is **not** itself a standards-track specification.
+- An explainer should not be mislabeled as the normative specification.
+
+## Community Group Report Requirements
+
+When authoring CG reports, ensure the document satisfies the report
+requirements:
+
+- Use the correct Community Group draft or final logo and style. ReSpec can
+  handle this when `specStatus` is set correctly.
+- Include the group name and a link to the public group page.
+- Include a publication date.
+- Do not use the W3C organization logo.
+- Do not cause confusion about standards status.
+- Make contribution history easy to find.
+- For final reports, ensure the final-report-specific FSA requirements are met.
+- Do not introduce third-party tracking that violates W3C privacy policy.
+
+For authoring text, prefer the exact W3C framing. Do not improvise stronger or
+weaker status language if the official boilerplate already covers the point.
+
+## Standards-Track Readiness Guidance
+
+When writing a report that aims to support later standards-track adoption, make
+the following explicit:
+
+- Clear problem statement.
+- Explicit success criteria.
+- Well-socialized proposal, or a clear explanation of what socialization is
+  still missing.
+- Maturity level of the draft and what remains incubation-specific.
+- Evidence of user, implementer, and reviewer interest.
+- Evidence package: tests, implementations, interoperability work, opposition,
+  risks, and IPR readiness.
+- Clear statement that W3C is not being asked for a rubber stamp.
+
+Do not write a transition report as if a Working Group decision were already
+made.
+
+## Structural Patterns to Reuse
+
+These patterns repeatedly help Community Group work transition well:
+
+- Keep the title focused on the problem being solved, not only on process stage.
+- Separate the **problem**, the **proposed scope**, and the **evidence gaps**.
+- Distinguish what is candidate normative core from what remains informative,
+  project-specific, or experimental.
+- Include links to issue tracker, repository, and commit history.
+- If using a reference implementation, say so directly and explain which parts
+  are implementation detail versus candidate standard surface.
+- For transition-oriented reports, include a short adoption path:
+  incubation -> final Community Group report -> Working Group adoption.
+
+## Real W3C Examples
+
+Use these examples as structural models.
+
+### 1. Presentation API: Community Group report used as WG starting point
+
+Sources:
+
+- Second Screen Community Group:
+  <https://www.w3.org/community/webscreens/>
+- Transition announcement:
+  <https://www.w3.org/community/webscreens/2014/12/03/transitioning-the-presentation-api-to-the-second-screen-presentation-working-group/>
+- Second Screen Presentation Working Group Charter:
+  <https://www.w3.org/2014/secondscreen/charter.html>
+
+Why it matters:
+
+- The Community Group published a final report specifically to provide a
+  concrete starting point for the Working Group.
+- The charter says the initial version of the WG deliverable would be copied
+  from the Community Group final report.
+- The charter also separates what remains in scope for the WG from future
+  incubations in the CG.
+
+What to copy:
+
+- Narrow initial deliverable.
+- Clear Working Group scope.
+- Explicit bridge from CG final report to adopted draft.
+
+### 2. Decentralized Identifiers: final CG specification plus later WG adoption
+
+Sources:
+
+- DID v0.13 Final Community Group Report:
+  <https://www.w3.org/2019/08/did-20190828/>
+- DID WG minutes on adopting the final report:
+  <https://www.w3.org/2019/09/15-did-minutes.html>
+- DID WG charter example:
+  <https://www.w3.org/2024/03/proposed-wg-did.html>
+
+Why it matters:
+
+- The final CG report has a strong public surface: GitHub, bugs, commit
+  history, participation, and status boilerplate.
+- The Working Group explicitly discussed adopting the CG final report as the
+  first editors’ draft.
+- Later charters continue to identify incubated deliverables with draft state
+  such as “Draft Community Group Report”.
+
+What to copy:
+
+- Make contribution history and participation easy to find.
+- Preserve a direct line from CG report to WG adopted draft.
+- Be precise about each deliverable’s draft state.
+
+### 3. Verifiable Credentials WG charter: CG drafts as initial drafts
+
+Source:
+
+- Proposed VC WG charter:
+  <https://www.w3.org/2026/02/proposed-vc-wg-charter.html>
+
+Why it matters:
+
+- The charter lists multiple new normative specifications and, for each, states
+  draft state, expected completion, and the initial draft or adopted draft.
+- Several entries explicitly start from Draft Community Group Reports.
+
+What to copy:
+
+- Make future charter extraction easy.
+- For each candidate deliverable, state scope, current draft state, and what
+  existing document would serve as the initial or adopted draft.
+
+### 4. Touch Events final report: polished final-report surface
+
+Source:
+
+- Touch Events - Level 2:
+  <https://www.w3.org/community/reports/touchevents/CG-FINAL-touch-events-20240704/>
+
+Why it matters:
+
+- It shows a clean final-report structure with repository, bug tracker, commit
+  history, mailing list, boilerplate, and explicit relation to adjacent work.
+- It includes a direct note about maintenance status and legacy position.
+
+What to copy:
+
+- Strong public participation surface.
+- Clear status language.
+- Explicit relationship to adjacent or successor work.
+
+## Instructions for LLMs Using `respec-mcp`
+
+When operating this MCP, follow this sequence:
+
+1. `respec_list_profiles`
+   - discover the profile and allowed statuses.
+2. Read the repo-local profile and templates.
+3. If the target is a W3C/CG report, read the W3C report requirements.
+4. If the target supports later standards work, read the W3C readiness and CG
+   transition guidance.
+5. Draft or edit the source.
+6. Run `respec_validate`.
+7. Run `respec_preflight`.
+8. Only then run `respec_build`.
+
+While writing:
+
+- Keep paragraphs short.
+- Prefer concrete section headings over vague narrative.
+- Focus titles on the problem or deliverable, not only on process mechanics.
+- Do not claim endorsement or standards status.
+- Separate normative candidate content from reference-implementation detail.
+- Include issue tracker, repository, and contribution history links whenever
+  appropriate.
+- If a report supports standards-track transition, include:
+  - problem statement
+  - success criteria
+  - evidence and implementation status
+  - standards-track scope proposal
+  - evidence gaps and next steps
+
+## What Not to Do
+
+- Do not label a Community Group report as a W3C Standard.
+- Do not imply that a Working Group will merely rubber-stamp an existing draft.
+- Do not carry over all implementation detail from a reference implementation
+  into candidate normative text.
+- Do not omit evidence gaps just because the project has a working codebase.
+- Do not reduce the MCP workflow to “render whatever text already exists”.
+
+The MCP should help produce reviewable, standards-aware documents.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "packageManager": "pnpm@10.30.1",
   "bin": {
     "respec": "tools/respec2html.js",
-    "respec2html": "tools/respec2html.js"
+    "respec2html": "tools/respec2html.js",
+    "respec-mcp": "tools/respec-mcp.js"
   },
   "main": "./tools/respecDocWriter.js",
   "type": "module",
@@ -82,21 +83,27 @@
     "server": "serve",
     "start": "node ./tools/dev-server.cjs",
     "test:build": "jasmine --random=false ./tests/test-build.cjs",
+    "test:mcp": "jasmine --random=false ./tests/mcp.cjs",
     "test:headless": "jasmine --random=false ./tests/headless.cjs",
-    "test": "pnpm test:unit && pnpm test:integration",
+    "test": "pnpm test:unit && pnpm test:integration && pnpm test:mcp",
     "test:unit": "karma start ./tests/unit/karma.conf.cjs --single-run",
     "test:integration": "karma start ./tests/spec/karma.conf.cjs --single-run"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.21.0",
     "colors": "1.4.0",
     "finalhandler": "^2.1.1",
     "marked": "^17.0.5",
     "puppeteer": "^24.40.0",
     "sade": "^1.8.1",
-    "serve-static": "^2.2.1"
+    "serve-static": "^2.2.1",
+    "zod": "^3.25.76"
   },
   "files": [
     "builds/",
+    "tools/respec-mcp.js",
+    "tools/respecMcpCore.js",
+    "tools/respecMcpServer.js",
     "tools/respec2html.js",
     "tools/respecDocWriter.js"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.21.0
+        version: 1.29.0(zod@3.25.76)
       colors:
         specifier: 1.4.0
         version: 1.4.0
@@ -26,6 +29,9 @@ importers:
       serve-static:
         specifier: ^2.2.1
         version: 2.2.1
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@eslint/js':
         specifier: ^9.8.0
@@ -204,6 +210,12 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hono/node-server@1.19.13':
+    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -247,6 +259,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.20':
     resolution: {integrity: sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -532,6 +554,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -545,6 +571,9 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -711,6 +740,10 @@ packages:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
@@ -876,12 +909,24 @@ packages:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.4.2:
     resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cors@2.8.5:
@@ -1242,6 +1287,14 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -1249,6 +1302,16 @@ packages:
   exit-hook@1.1.1:
     resolution: {integrity: sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==}
     engines: {node: '>=0.10.0'}
+
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1334,6 +1397,10 @@ packages:
   foreground-child@3.1.1:
     resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
     engines: {node: '>=14'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -1467,6 +1534,10 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
+  hono@4.12.12:
+    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+    engines: {node: '>=16.9.0'}
+
   html-minifier@4.0.0:
     resolution: {integrity: sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==}
     engines: {node: '>=6'}
@@ -1474,6 +1545,10 @@ packages:
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
   http-proxy-agent@7.0.2:
@@ -1503,6 +1578,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   idb@8.0.3:
@@ -1537,6 +1616,10 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1625,6 +1708,9 @@ packages:
     resolution: {integrity: sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
@@ -1698,6 +1784,9 @@ packages:
     resolution: {integrity: sha512-WPphPqEMY0uBRMjuhRHoVoxQNvJuxIMqz0yIcJ3k3oYxBedeGoH60/NXNgasxnx2FvfXrq5/r+2wssJ7WE8ABw==}
     hasBin: true
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1716,6 +1805,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1827,6 +1919,14 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -1912,6 +2012,10 @@ packages:
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
   netmask@2.0.2:
@@ -2050,6 +2154,9 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -2063,6 +2170,10 @@ packages:
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -2092,6 +2203,10 @@ packages:
   prompt@1.3.0:
     resolution: {integrity: sha512-ZkaRWtaLBZl7KKAKndKYUL8WqNT+cQHKRZnT4RYYms48jQkFw3rrBL+/N5K/KtdEveHkxs982MX2BkDKub2ZMg==}
     engines: {node: '>= 6.0.0'}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
 
   proxy-agent@6.5.0:
     resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
@@ -2124,6 +2239,10 @@ packages:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -2135,6 +2254,10 @@ packages:
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2218,6 +2341,10 @@ packages:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -2367,6 +2494,10 @@ packages:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -2499,6 +2630,10 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   typed-array-buffer@1.0.3:
@@ -2703,6 +2838,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -2766,6 +2906,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@1.19.13(hono@4.12.12)':
+    dependencies:
+      hono: 4.12.12
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -2809,6 +2953,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.12)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3031,6 +3197,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3038,6 +3209,10 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1:
+    dependencies:
+      ajv: 8.18.0
 
   ajv@6.14.0:
     dependencies:
@@ -3210,6 +3385,20 @@ snapshots:
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.0
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -3406,9 +3595,15 @@ snapshots:
 
   content-disposition@0.5.2: {}
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.4.2: {}
+
+  cookie@0.7.2: {}
 
   cors@2.8.5:
     dependencies:
@@ -3829,6 +4024,12 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  eventsource-parser@3.0.6: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -3842,6 +4043,44 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit-hook@1.1.1: {}
+
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.1
+      statuses: 2.0.1
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -3930,6 +4169,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
 
@@ -4066,6 +4307,8 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  hono@4.12.12: {}
+
   html-minifier@4.0.0:
     dependencies:
       camel-case: 3.0.0
@@ -4082,6 +4325,14 @@ snapshots:
       inherits: 2.0.4
       setprototypeof: 1.2.0
       statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
       toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
@@ -4131,6 +4382,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   idb@8.0.3: {}
 
   ignore@5.3.0: {}
@@ -4158,6 +4413,8 @@ snapshots:
       side-channel: 1.1.0
 
   ip-address@10.1.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4234,6 +4491,8 @@ snapshots:
 
   is-port-reachable@4.0.0: {}
 
+  is-promise@4.0.0: {}
+
   is-reference@1.2.1:
     dependencies:
       '@types/estree': 1.0.8
@@ -4307,6 +4566,8 @@ snapshots:
       glob: 10.4.5
       jasmine-core: 6.1.0
 
+  jose@6.2.2: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -4320,6 +4581,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4456,6 +4719,10 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   mime-db@1.33.0: {}
@@ -4523,6 +4790,8 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
+
+  negotiator@1.0.0: {}
 
   netmask@2.0.2: {}
 
@@ -4672,6 +4941,8 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
+  path-to-regexp@8.4.2: {}
+
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
@@ -4679,6 +4950,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  pkce-challenge@5.0.1: {}
 
   pluralize@8.0.0: {}
 
@@ -4701,6 +4974,11 @@ snapshots:
       read: 1.0.7
       revalidator: 0.1.8
       winston: 2.4.7
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
 
   proxy-agent@6.5.0:
     dependencies:
@@ -4764,6 +5042,10 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   range-parser@1.2.0: {}
 
   range-parser@1.2.1: {}
@@ -4773,6 +5055,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc@1.2.8:
@@ -4890,6 +5179,16 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.60.1
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
 
   sade@1.8.1:
     dependencies:
@@ -5099,6 +5398,8 @@ snapshots:
 
   statuses@2.0.1: {}
 
+  statuses@2.0.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -5274,6 +5575,12 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -5487,5 +5794,9 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/tests/mcp.cjs
+++ b/tests/mcp.cjs
@@ -1,0 +1,224 @@
+const os = require("os");
+const path = require("path");
+const {
+  promises: { mkdtemp, mkdir, rm, writeFile, readFile },
+} = require("fs");
+
+describe("respec MCP core", () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
+
+  let tempRoot;
+  let api;
+
+  beforeAll(async () => {
+    api = await import("../tools/respecMcpCore.js");
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), "respec-mcp-"));
+    await mkdir(path.join(tempRoot, "respec-mcp/profiles"), { recursive: true });
+    await mkdir(path.join(tempRoot, "respec-mcp/templates"), { recursive: true });
+    await mkdir(path.join(tempRoot, "reports/source"), { recursive: true });
+
+    await writeFile(
+      path.join(tempRoot, "respec-mcp.config.json"),
+      JSON.stringify(
+        {
+          default_profile: "example-cg",
+          profile_directory: "respec-mcp/profiles",
+          source_root: "reports/source",
+          build_root: "reports/build",
+          template_defaults: {
+            github: "example/spec",
+            latestVersion: "https://example.test/spec/",
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    await writeFile(
+      path.join(tempRoot, "w3c.json"),
+      JSON.stringify(
+        {
+          group: [174898],
+          contacts: ["editor@example.test"],
+          "repo-type": "cg-report",
+        },
+        null,
+        2
+      )
+    );
+
+    await writeFile(
+      path.join(tempRoot, "respec-mcp/profiles/example-cg.json"),
+      JSON.stringify(
+        {
+          profile_id: "example-cg",
+          label: "Example CG",
+          group_type: "cg",
+          allowed_statuses: ["CG-DRAFT", "CG-FINAL"],
+          default_status: "CG-DRAFT",
+          repo_metadata_source: "w3c.json",
+          source_root: "reports/source",
+          build_root: "reports/build",
+          default_source: "reports/source/index.html",
+          status_templates: {
+            "CG-DRAFT": "respec-mcp/templates/cg-draft.html",
+            "CG-FINAL": "respec-mcp/templates/cg-final.html",
+          },
+          respec_defaults: {
+            title: "Example Spec",
+            shortName: "example-spec",
+            group: "cg/pm-kr",
+            editors: [
+              {
+                name: "Example Editor",
+                company: "Example Org",
+              },
+            ],
+          },
+          required_sections: [
+            "Abstract",
+            "Introduction",
+            "Use Cases",
+            "Security Considerations",
+            "Privacy Considerations",
+          ],
+          required_links: [
+            "https://www.w3.org/community/example/",
+            "https://github.com/example/spec",
+          ],
+          forbidden_phrases: ["W3C Recommendation"],
+        },
+        null,
+        2
+      )
+    );
+
+    const template = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{title}}</title>
+    <script class="remove">
+      const respecConfig = {
+        specStatus: {{specStatusJson}},
+        shortName: {{shortNameJson}},
+        group: {{groupJson}},
+        github: {{githubJson}},
+        latestVersion: {{latestVersionJson}},
+        editors: {{editorsJson}},
+      };
+    </script>
+    <script async class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+  </head>
+  <body>
+    <section id="abstract"><p>Abstract</p></section>
+    <section id="sotd"><p>Draft Community Group Report</p></section>
+    <section><h2>Introduction</h2><p>https://www.w3.org/community/example/</p></section>
+    <section><h2>Use Cases</h2><p>https://github.com/example/spec</p></section>
+    <section><h2>Security Considerations</h2><p>Security.</p></section>
+    <section><h2>Privacy Considerations</h2><p>Privacy.</p></section>
+  </body>
+</html>`;
+
+    await writeFile(
+      path.join(tempRoot, "respec-mcp/templates/cg-draft.html"),
+      template
+    );
+    await writeFile(
+      path.join(tempRoot, "respec-mcp/templates/cg-final.html"),
+      template.replace("Draft Community Group Report", "Final Community Group Report")
+    );
+  });
+
+  afterAll(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("lists profiles from repo-local config", async () => {
+    const result = await api.listProfiles(tempRoot);
+    expect(result.default_profile).toBe("example-cg");
+    expect(result.profiles.length).toBe(1);
+    expect(result.profiles[0].profile_id).toBe("example-cg");
+  });
+
+  it("scaffolds a source from the profile template", async () => {
+    const result = await api.scaffoldSource({
+      repo_root: tempRoot,
+      profile: "example-cg",
+      status: "CG-DRAFT",
+      output: "reports/source/index.html",
+      overrides: {
+        title: "Example CG Draft",
+      },
+    });
+    expect(result.status).toBe("CG-DRAFT");
+    expect(result.compliance.valid).toBeTrue();
+    const output = await readFile(path.join(tempRoot, "reports/source/index.html"), "utf-8");
+    expect(output).toContain("Example CG Draft");
+    expect(output).toContain("CG-DRAFT");
+  });
+
+  it("builds HTML and returns compliance output", async () => {
+    const result = await api.buildSpec(
+      {
+        repo_root: tempRoot,
+        profile: "example-cg",
+        source: "reports/source/index.html",
+      },
+      {
+        useLocal: true,
+        disableSandbox: true,
+        timeout: 60000,
+      }
+    );
+    expect(result.errors.length).toBe(0);
+    expect(result.compliance.valid).toBeTrue();
+    expect(result.output).toContain(path.join("reports", "build", "index.html"));
+  });
+
+  it("flags forbidden phrases during preflight", async () => {
+    await writeFile(
+      path.join(tempRoot, "reports/source/bad.html"),
+      `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Bad</title>
+    <script class="remove">
+      const respecConfig = {
+        specStatus: "CG-DRAFT",
+        shortName: "bad",
+        group: "cg/pm-kr",
+        github: "example/spec",
+      };
+    </script>
+    <script async class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+  </head>
+  <body>
+    <section id="abstract"><p>W3C Recommendation</p></section>
+    <section><h2>Introduction</h2><p>Intro</p></section>
+    <section><h2>Use Cases</h2><p>Use</p></section>
+    <section><h2>Security Considerations</h2><p>Sec</p></section>
+    <section><h2>Privacy Considerations</h2><p>Privacy</p></section>
+  </body>
+</html>`
+    );
+
+    const result = await api.preflightSpec(
+      {
+        repo_root: tempRoot,
+        profile: "example-cg",
+        source: "reports/source/bad.html",
+      },
+      {
+        useLocal: true,
+        disableSandbox: true,
+        timeout: 60000,
+      }
+    );
+
+    expect(result.compliance.valid).toBeFalse();
+    expect(result.compliance.forbidden_phrase_hits).toContain("W3C Recommendation");
+  });
+});

--- a/tools/respec-mcp.js
+++ b/tools/respec-mcp.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import path from "path";
+import sade from "sade";
+import { readFile } from "fs/promises";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createReSpecMcpServer } from "./respecMcpServer.js";
+
+const cli = sade("respec-mcp", true)
+  .describe("Runs the ReSpec MCP server over stdio.")
+  .option("--repo-root", "Default repo root for tool calls.", process.cwd())
+  .option("--profile", "Default profile id for tool calls.")
+  .option(
+    "--timeout",
+    "How long to wait before timing out ReSpec rendering (in milliseconds).",
+    300000
+  )
+  .option("--use-local", "Use the locally built ReSpec bundle if requested.", false)
+  .option("--disable-sandbox", "Disable Chromium sandboxing.", false)
+  .option("--disable-gpu", "Disable GPU usage in Chromium.", false)
+  .option("--devtools", "Run Chromium with devtools open.", false);
+
+cli.action(async opts => {
+  try {
+    const version = await readVersion();
+    const server = createReSpecMcpServer({
+      version,
+      defaultRepoRoot: path.resolve(opts["repo-root"]),
+      defaultProfile: opts.profile,
+      timeout: parseInt(String(opts.timeout), 10),
+      useLocal: Boolean(opts["use-local"]),
+      disableSandbox: Boolean(opts["disable-sandbox"]),
+      disableGPU: Boolean(opts["disable-gpu"]),
+      devtools: Boolean(opts.devtools),
+    });
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+  } catch (error) {
+    process.stderr.write(`${error.stack || error}\n`);
+    process.exit(1);
+  }
+});
+
+cli.parse(process.argv, {
+  unknown(flag) {
+    process.stderr.write(`Unknown option: ${flag}\n`);
+    process.exit(1);
+  },
+});
+
+async function readVersion() {
+  const packagePath = path.join(import.meta.dirname, "..", "package.json");
+  const { version } = JSON.parse(await readFile(packagePath, "utf-8"));
+  return version;
+}

--- a/tools/respecMcpCore.js
+++ b/tools/respecMcpCore.js
@@ -1,0 +1,486 @@
+import { mkdir, readFile, readdir, writeFile } from "fs/promises";
+import path from "path";
+import { pathToFileURL } from "url";
+import { toHTML } from "./respecDocWriter.js";
+
+export const CONFIG_FILENAME = "respec-mcp.config.json";
+export const AUTHORING_GUIDE_PATH = "docs/MCP_LLM_AUTHORING_GUIDE.md";
+
+const DEFAULT_STATUS = "CG-DRAFT";
+const DEFAULT_SOURCE_ROOT = "reports/source";
+const DEFAULT_BUILD_ROOT = "reports/build";
+
+export async function loadJson(filePath) {
+  const source = await readFile(filePath, "utf-8");
+  return JSON.parse(source);
+}
+
+export async function fileExists(filePath) {
+  try {
+    await readFile(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadRepoConfig(repoRoot) {
+  const resolvedRoot = path.resolve(repoRoot || process.cwd());
+  const configPath = path.join(resolvedRoot, CONFIG_FILENAME);
+  const hasConfig = await fileExists(configPath);
+  const repoConfig = hasConfig
+    ? await loadJson(configPath)
+    : {
+        default_profile: null,
+        profile_directory: "respec-mcp/profiles",
+        source_root: DEFAULT_SOURCE_ROOT,
+        build_root: DEFAULT_BUILD_ROOT,
+      };
+
+  return {
+    repoRoot: resolvedRoot,
+    configPath: hasConfig ? configPath : null,
+    config: repoConfig,
+  };
+}
+
+export async function listProfiles(repoRoot) {
+  const repoState = await loadRepoConfig(repoRoot);
+  const profiles = await loadProfiles(repoState);
+  return {
+    repo_root: repoState.repoRoot,
+    config_path: repoState.configPath,
+    authoring_guidance_path: AUTHORING_GUIDE_PATH,
+    default_profile: repoState.config.default_profile || null,
+    profiles: profiles.map(profile => ({
+      profile_id: profile.profile_id,
+      label: profile.label || profile.profile_id,
+      allowed_statuses: profile.allowed_statuses || [],
+      default_status: profile.default_status || DEFAULT_STATUS,
+      repo_metadata_source: profile.repo_metadata_source || null,
+    })),
+  };
+}
+
+export async function scaffoldSource(input, options = {}) {
+  const state = await resolveContext(input, options);
+  const metadata = await loadRepoMetadata(state.repoRoot, state.profile.repo_metadata_source);
+  const sourcePath = resolveScaffoldPath(state, input.output);
+  const templatePath = resolveTemplatePath(state.profile, state.status, state.repoRoot);
+  const template = await readFile(templatePath, "utf-8");
+  const rendered = applyTemplate(
+    template,
+    buildTemplateContext(state, metadata, input.overrides)
+  );
+  await mkdir(path.dirname(sourcePath), { recursive: true });
+  await writeFile(sourcePath, rendered, "utf-8");
+
+  const compliance = await evaluateCompliance({
+    html: rendered,
+    sourceText: rendered,
+    profile: state.profile,
+    repoRoot: state.repoRoot,
+    status: state.status,
+    errors: [],
+    warnings: [],
+  });
+
+  return {
+    source: sourcePath,
+    output: sourcePath,
+    status: state.status,
+    authoring_guidance_path: AUTHORING_GUIDE_PATH,
+    errors: [],
+    warnings: [],
+    compliance,
+    resolved_profile: summarizeProfile(state.profile),
+    resolved_repo_config: summarizeRepoConfig(state.repoState),
+  };
+}
+
+export async function buildSpec(input, options = {}) {
+  return renderAndAssess(input, options, { writeOutput: true });
+}
+
+export async function validateSpec(input, options = {}) {
+  return renderAndAssess(input, options, { writeOutput: false });
+}
+
+export async function preflightSpec(input, options = {}) {
+  return renderAndAssess(input, options, { writeOutput: false });
+}
+
+async function renderAndAssess(input, options, behavior) {
+  const state = await resolveContext(input, options);
+  const sourceRef = resolveSourceReference(state, input.source);
+  const sourceUrl = toSourceUrl(sourceRef, state.repoRoot);
+  const sourceText = await readSourceText(sourceRef, state.repoRoot);
+  const outputPath =
+    behavior.writeOutput && resolveOutputPath(state, input.output, sourceRef);
+  const errors = [];
+  const warnings = [];
+  const { html, errors: rsErrors, warnings: rsWarnings } = await toHTML(sourceUrl, {
+    timeout: options.timeout || 300000,
+    useLocal: Boolean(options.useLocal),
+    disableSandbox: Boolean(options.disableSandbox),
+    disableGPU: Boolean(options.disableGPU),
+    devtools: Boolean(options.devtools),
+    onError: error => errors.push(sanitizeReSpecError(error)),
+    onWarning: warning => warnings.push(sanitizeReSpecError(warning)),
+  });
+
+  // Keep the callback arrays authoritative if ReSpec returns duplicates or a future
+  // version stops pushing via callbacks.
+  if (!errors.length && rsErrors.length) {
+    errors.push(...rsErrors.map(sanitizeReSpecError));
+  }
+  if (!warnings.length && rsWarnings.length) {
+    warnings.push(...rsWarnings.map(sanitizeReSpecError));
+  }
+
+  const compliance = await evaluateCompliance({
+    html,
+    sourceText,
+    profile: state.profile,
+    repoRoot: state.repoRoot,
+    status: state.status,
+    errors,
+    warnings,
+  });
+
+  if (outputPath) {
+    await mkdir(path.dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, html, "utf-8");
+  }
+
+  return {
+    source: sourceUrl,
+    output: outputPath || null,
+    status: state.status,
+    authoring_guidance_path: AUTHORING_GUIDE_PATH,
+    errors,
+    warnings,
+    compliance,
+    resolved_profile: summarizeProfile(state.profile),
+    resolved_repo_config: summarizeRepoConfig(state.repoState),
+  };
+}
+
+async function resolveContext(input, options) {
+  const repoRoot = path.resolve(
+    input.repo_root || options.defaultRepoRoot || process.cwd()
+  );
+  const repoState = await loadRepoConfig(repoRoot);
+  const profiles = await loadProfiles(repoState);
+  const profileId =
+    input.profile ||
+    options.defaultProfile ||
+    repoState.config.default_profile ||
+    profiles[0]?.profile_id;
+
+  if (!profileId) {
+    throw new Error(
+      `No profiles are configured for ${repoRoot}. Add ${CONFIG_FILENAME} and a profile JSON file.`
+    );
+  }
+
+  const profile = profiles.find(item => item.profile_id === profileId);
+  if (!profile) {
+    throw new Error(`Profile "${profileId}" was not found under ${repoRoot}.`);
+  }
+
+  const status =
+    input.status || profile.default_status || repoState.config.default_status || DEFAULT_STATUS;
+  ensureStatusAllowed(profile, status);
+
+  return {
+    repoRoot,
+    repoState,
+    profile,
+    status,
+  };
+}
+
+async function loadProfiles(repoState) {
+  const config = repoState.config;
+  const configuredProfiles = Array.isArray(config.profile_paths)
+    ? config.profile_paths
+    : [];
+  const discoveredProfiles = configuredProfiles.length
+    ? configuredProfiles
+    : await discoverProfiles(repoState.repoRoot, config.profile_directory);
+
+  const loaded = [];
+  for (const item of discoveredProfiles) {
+    const profilePath = path.resolve(repoState.repoRoot, item);
+    const profile = await loadJson(profilePath);
+    loaded.push({
+      ...profile,
+      __path: profilePath,
+    });
+  }
+  return loaded;
+}
+
+async function discoverProfiles(repoRoot, profileDirectory = "respec-mcp/profiles") {
+  const profileRoot = path.resolve(repoRoot, profileDirectory);
+  try {
+    const entries = await readdir(profileRoot, { withFileTypes: true });
+    return entries
+      .filter(entry => entry.isFile() && entry.name.endsWith(".json"))
+      .map(entry => path.join(profileDirectory, entry.name))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function ensureStatusAllowed(profile, status) {
+  const allowed = profile.allowed_statuses || [];
+  if (allowed.length && !allowed.includes(status)) {
+    throw new Error(
+      `Status "${status}" is not allowed for profile "${profile.profile_id}". Allowed: ${allowed.join(", ")}`
+    );
+  }
+}
+
+function resolveSourceReference(state, sourceInput) {
+  const source =
+    sourceInput ||
+    state.profile.default_source ||
+    joinIfPresent(state.repoState.config.source_root, "index.html");
+  if (!source) {
+    throw new Error(
+      `No source was provided and profile "${state.profile.profile_id}" has no default_source.`
+    );
+  }
+  return source;
+}
+
+function resolveScaffoldPath(state, output) {
+  if (output) {
+    return path.resolve(state.repoRoot, output);
+  }
+
+  const defaultSource =
+    state.profile.default_source ||
+    path.join(state.repoState.config.source_root || DEFAULT_SOURCE_ROOT, "index.html");
+  return path.resolve(state.repoRoot, defaultSource);
+}
+
+function resolveTemplatePath(profile, status, repoRoot) {
+  const byStatus = profile.status_templates || {};
+  const templatePath = byStatus[status] || profile.template_path;
+  if (!templatePath) {
+    throw new Error(
+      `Profile "${profile.profile_id}" does not define a template for status "${status}".`
+    );
+  }
+  return path.resolve(repoRoot, templatePath);
+}
+
+function resolveOutputPath(state, explicitOutput, sourceRef) {
+  if (explicitOutput) {
+    return path.resolve(state.repoRoot, explicitOutput);
+  }
+
+  if (/^\w+:\/\//.test(sourceRef)) {
+    return null;
+  }
+
+  const buildRoot =
+    state.profile.build_root ||
+    state.repoState.config.build_root ||
+    DEFAULT_BUILD_ROOT;
+  const sourceRoot =
+    state.profile.source_root ||
+    state.repoState.config.source_root ||
+    DEFAULT_SOURCE_ROOT;
+
+  const absoluteSource = path.resolve(state.repoRoot, sourceRef);
+  const absoluteSourceRoot = path.resolve(state.repoRoot, sourceRoot);
+  const absoluteBuildRoot = path.resolve(state.repoRoot, buildRoot);
+
+  if (absoluteSource.startsWith(`${absoluteSourceRoot}${path.sep}`)) {
+    const relative = path.relative(absoluteSourceRoot, absoluteSource);
+    return path.resolve(absoluteBuildRoot, relative);
+  }
+
+  return path.resolve(absoluteBuildRoot, path.basename(absoluteSource));
+}
+
+function toSourceUrl(sourceRef, repoRoot) {
+  if (/^\w+:\/\//.test(sourceRef)) {
+    return sourceRef;
+  }
+  const absolutePath = path.isAbsolute(sourceRef)
+    ? sourceRef
+    : path.resolve(repoRoot, sourceRef);
+  return pathToFileURL(absolutePath).href;
+}
+
+async function readSourceText(sourceRef, repoRoot) {
+  if (/^\w+:\/\//.test(sourceRef)) {
+    const response = await fetch(sourceRef);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch source ${sourceRef}: ${response.status}`);
+    }
+    return await response.text();
+  }
+  return await readFile(path.resolve(repoRoot, sourceRef), "utf-8");
+}
+
+async function evaluateCompliance({
+  html,
+  sourceText,
+  profile,
+  repoRoot,
+  status,
+  errors,
+  warnings,
+}) {
+  const metadata = await loadRepoMetadata(repoRoot, profile.repo_metadata_source);
+  const htmlLower = html.toLowerCase();
+  const sourceLower = sourceText.toLowerCase();
+  const requiredSectionsMissing = (profile.required_sections || []).filter(
+    section => !htmlLower.includes(section.toLowerCase())
+  );
+  const requiredLinksMissing = (profile.required_links || []).filter(
+    link => !html.includes(link)
+  );
+  const forbiddenPhraseHits = (profile.forbidden_phrases || []).filter(phrase => {
+    const lowerPhrase = phrase.toLowerCase();
+    return htmlLower.includes(lowerPhrase) || sourceLower.includes(lowerPhrase);
+  });
+
+  const metadataChecks = {
+    found: metadata.found,
+    path: metadata.path,
+    group_id: metadata.groupId,
+    repo_type: metadata.repoType,
+    expected_group_type: profile.group_type || null,
+  };
+
+  return {
+    valid:
+      !errors.length &&
+      !requiredSectionsMissing.length &&
+      !requiredLinksMissing.length &&
+      !forbiddenPhraseHits.length,
+    status_allowed:
+      !profile.allowed_statuses ||
+      !profile.allowed_statuses.length ||
+      profile.allowed_statuses.includes(status),
+    metadata_checks: metadataChecks,
+    required_sections_missing: requiredSectionsMissing,
+    required_links_missing: requiredLinksMissing,
+    forbidden_phrase_hits: forbiddenPhraseHits,
+    warnings_count: warnings.length,
+    errors_count: errors.length,
+  };
+}
+
+async function loadRepoMetadata(repoRoot, metadataSource) {
+  if (!metadataSource) {
+    return {
+      found: false,
+      path: null,
+      groupId: null,
+      repoType: null,
+    };
+  }
+
+  const metadataPath = path.resolve(repoRoot, metadataSource);
+  if (!(await fileExists(metadataPath))) {
+    return {
+      found: false,
+      path: metadataPath,
+      groupId: null,
+      repoType: null,
+    };
+  }
+
+  const metadata = await loadJson(metadataPath);
+  return {
+    found: true,
+    path: metadataPath,
+    groupId: Array.isArray(metadata.group) ? metadata.group[0] : null,
+    repoType: metadata["repo-type"] || null,
+  };
+}
+
+function buildTemplateContext(state, metadata, overrides = {}) {
+  const repoDefaults = state.repoState.config.template_defaults || {};
+  const profileDefaults = state.profile.respec_defaults || {};
+
+  const merged = {
+    title: "Untitled Community Group Report",
+    subtitle: "",
+    shortName: "pm-kr",
+    group: null,
+    github: null,
+    latestVersion: null,
+    editors: [],
+    publishDate: new Date().toISOString().slice(0, 10),
+    specStatus: state.status,
+    groupId: metadata.groupId,
+    repoType: metadata.repoType,
+    ...repoDefaults,
+    ...profileDefaults,
+    ...overrides,
+  };
+
+  return addJsonValues(merged);
+}
+
+function addJsonValues(values) {
+  const result = { ...values };
+  for (const [key, value] of Object.entries(values)) {
+    result[`${key}Json`] = JSON.stringify(value);
+  }
+  return result;
+}
+
+function applyTemplate(template, values) {
+  return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key) => {
+    if (!(key in values)) {
+      return "";
+    }
+    const value = values[key];
+    return value === null || value === undefined ? "" : String(value);
+  });
+}
+
+function sanitizeReSpecError(error) {
+  return {
+    message: error.message,
+    plugin: error.plugin || null,
+    hint: error.hint || null,
+  };
+}
+
+function summarizeProfile(profile) {
+  return {
+    profile_id: profile.profile_id,
+    label: profile.label || profile.profile_id,
+    allowed_statuses: profile.allowed_statuses || [],
+    default_status: profile.default_status || DEFAULT_STATUS,
+    source_root: profile.source_root || null,
+    build_root: profile.build_root || null,
+    repo_metadata_source: profile.repo_metadata_source || null,
+  };
+}
+
+function summarizeRepoConfig(repoState) {
+  return {
+    repo_root: repoState.repoRoot,
+    config_path: repoState.configPath,
+    default_profile: repoState.config.default_profile || null,
+    source_root: repoState.config.source_root || DEFAULT_SOURCE_ROOT,
+    build_root: repoState.config.build_root || DEFAULT_BUILD_ROOT,
+  };
+}
+
+function joinIfPresent(root, leaf) {
+  return root ? path.join(root, leaf) : null;
+}

--- a/tools/respecMcpServer.js
+++ b/tools/respecMcpServer.js
@@ -1,0 +1,111 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import {
+  buildSpec,
+  listProfiles,
+  preflightSpec,
+  scaffoldSource,
+  validateSpec,
+} from "./respecMcpCore.js";
+
+const baseSchema = {
+  repo_root: z.string().optional(),
+  profile: z.string().optional(),
+  status: z.string().optional(),
+  strict: z.boolean().optional(),
+  overrides: z.record(z.any()).optional(),
+};
+
+const renderSchema = {
+  ...baseSchema,
+  source: z.string().optional(),
+  output: z.string().optional(),
+};
+
+export function createReSpecMcpServer(options = {}) {
+  const server = new McpServer({
+    name: "respec-mcp",
+    version: options.version || "0.1.0",
+  });
+
+  const toolOptions = {
+    defaultRepoRoot: options.defaultRepoRoot,
+    defaultProfile: options.defaultProfile,
+    timeout: options.timeout,
+    useLocal: options.useLocal,
+    disableSandbox: options.disableSandbox,
+    disableGPU: options.disableGPU,
+    devtools: options.devtools,
+  };
+
+  server.registerTool(
+    "respec_list_profiles",
+    {
+      title: "List ReSpec MCP Profiles",
+      description:
+        "Lists repo-local ReSpec MCP profiles discovered from respec-mcp.config.json and respec-mcp/profiles/*.json.",
+      inputSchema: z.object({
+        repo_root: z.string().optional(),
+      }),
+    },
+    async input => formatResult(await listProfiles(input.repo_root || toolOptions.defaultRepoRoot))
+  );
+
+  server.registerTool(
+    "respec_scaffold",
+    {
+      title: "Scaffold ReSpec Source",
+      description:
+        "Creates a ReSpec source document from a repo-local profile and status-specific template.",
+      inputSchema: z.object(renderSchema),
+    },
+    async input => formatResult(await scaffoldSource(input, toolOptions))
+  );
+
+  server.registerTool(
+    "respec_build",
+    {
+      title: "Build ReSpec Document",
+      description:
+        "Renders a ReSpec source file or URL to static HTML using the resolved repo-local profile.",
+      inputSchema: z.object(renderSchema),
+    },
+    async input => formatResult(await buildSpec(input, toolOptions))
+  );
+
+  server.registerTool(
+    "respec_validate",
+    {
+      title: "Validate ReSpec Document",
+      description:
+        "Runs ReSpec and returns render diagnostics plus profile-based compliance results without writing output by default.",
+      inputSchema: z.object(renderSchema),
+    },
+    async input => formatResult(await validateSpec(input, toolOptions))
+  );
+
+  server.registerTool(
+    "respec_preflight",
+    {
+      title: "Preflight Community Group Report",
+      description:
+        "Performs repo/profile policy checks for a ReSpec document, including status, required sections, required links, and forbidden phrases.",
+      inputSchema: z.object(renderSchema),
+    },
+    async input => formatResult(await preflightSpec(input, toolOptions))
+  );
+
+  return server;
+}
+
+function formatResult(result) {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(result, null, 2),
+      },
+    ],
+    structuredContent: result,
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds a configurable stdio MCP companion for ReSpec so AI tools and editors can scaffold, preflight, validate, and build reports from repo-local profiles.

## What Changed

- add `respec-mcp` stdio entrypoints and MCP core/server modules
- add repo-local profile/config discovery via `respec-mcp.config.json` and `respec-mcp/profiles/*.json`
- add Docker runtime for Node 24 + Chromium environments
- add focused MCP tests
- add LLM authoring guidance for W3C and Community Group report workflows, including standards-transition patterns and examples
- expose the authoring guidance path in MCP responses so clients can discover and apply it

## Why

The goal is to let Community Groups and similar spec repositories keep local policy and templates while reusing one upstream MCP runtime. The added authoring guidance is meant to make the MCP useful for real standards-oriented writing and review, not only for rendering HTML.

## Validation

- `docker build -t respec-mcp:local .`
- `docker run --rm --entrypoint node respec-mcp:local /app/node_modules/jasmine/bin/jasmine.js --random=false /app/tests/mcp.cjs`
