### PR TITLE
fix(error-messages): improve hints in xref and link-to-dfn

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -5,6 +5,7 @@
 import {
   CaseInsensitiveMap,
   addId,
+  docLink,
   getIntlData,
   getLinkTargets,
   showError,
@@ -311,8 +312,15 @@ function shouldWrapByCode(elem, term = "") {
 function showLinkingError(elems) {
   elems.forEach(elem => {
     const msg = `Found linkless \`<a>\` element with text "${elem.textContent}" but no matching \`<dfn>\``;
-    const title = "Linking error: not matching `<dfn>`";
-    showWarning(msg, name, { title, elements: [elem] });
+    const title = "Linking error: no matching `<dfn>`";
+    // Check if the link is inside a data-link-for section — a common footgun
+    // where [=global-term=] gets scoped to the interface and fails.
+    const scopedSection = elem.closest("[data-link-for]");
+    const scopingNote = scopedSection
+      ? ` This link is inside a \`data-link-for="${scopedSection.dataset.linkFor}"\` section — \`[=term=]\` links are scoped to that context. To link to a global concept instead, either add \`data-link-for=""\` on this <a>, move it outside the scoped section, or use a plain \`<a>term</a>\` link.`
+      : "";
+    const hint = `Add a matching \`<dfn>\` element, ${docLink`use ${"[data-cite]"} to link to an external definition, or enable ${"[xref]"} for automatic cross-spec linking.`}${scopingNote}`;
+    showWarning(msg, name, { title, hint, elements: [elem] });
   });
 }
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -317,7 +317,7 @@ function showLinkingError(elems) {
     // where [=global-term=] gets scoped to the interface and fails.
     const scopedSection = elem.closest("[data-link-for]");
     const scopingNote = scopedSection
-      ? ` This link is inside a \`data-link-for="${scopedSection.dataset.linkFor}"\` section — \`[=term=]\` links are scoped to that context. To link to a global concept instead, either add \`data-link-for=""\` on this <a>, move it outside the scoped section, or use a plain \`<a>term</a>\` link.`
+      ? ` This link is inside a \`data-link-for="${scopedSection.dataset.linkFor}"\` section — \`[=term=]\` links are scoped to that context. To link to a global concept instead, either add \`data-link-for=""\` on this \`<a>\` or move it outside the scoped section.`
       : "";
     const hint = `Add a matching \`<dfn>\` element, ${docLink`use ${"[data-cite]"} to link to an external definition, or enable ${"[xref]"} for automatic cross-spec linking.`}${scopingNote}`;
     showWarning(msg, name, { title, hint, elements: [elem] });

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -145,7 +145,8 @@ function normalizeConfig(xref) {
       break;
     default: {
       const msg = `Invalid value for \`xref\` configuration option. Received: "${xref}".`;
-      showError(msg, name);
+      const hint = docLink`Expected: \`true\`, a profile name (e.g. \`"web-platform"\`), an array of spec shortnames (e.g. \`["FETCH", "DOM"]\`), or an object with \`url\`, \`specs\`, or \`profile\` properties. See ${"[xref]"}.`;
+      showError(msg, name, { hint });
     }
   }
   return config;


### PR DESCRIPTION
## Summary

- **xref.js**: invalid `xref` config value had no hint. Now explains the four valid forms (boolean, profile name, array, object) and links to docs via `docLink`.
- **link-to-dfn.js**: linkless `<a>` warning had no hint. Now suggests adding a `<dfn>`, using `data-cite`, or enabling `xref`. Also detects when the link is inside a `data-link-for` section and warns about scoping.

Split from #5135; MDN hint improvement is in #5137.

## Test plan

- [ ] `pnpm start --browser ChromeHeadless --grep="link-to-dfn"` — existing tests pass
- [ ] `pnpm start --browser ChromeHeadless --grep="xref"` — existing tests pass
