### PR TITLE
fix: keep heading alignment stable when addSectionLinks is false

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -140,7 +140,7 @@ aside.example .marker > a.self-link {
   align-items: baseline;
 }
 
-:is(h2, h3, h4, h5, h6):not(#toc > h2, #abstract > h2, #sotd > h2, .head > h2) {
+:is(h2, h3, h4, h5, h6):not(#toc > h2, #abstract > h2, #sotd > h2, .head > h2):has(+ a.self-link) {
   position: relative;
   left: -.5em;
 }


### PR DESCRIPTION
Fixes #4448

The heading offset is now applied only when a heading actually has an adjacent section self-link. With `addSectionLinks: false`, numbered headings keep the same alignment as when links are enabled.

Greetings, saschabuehrle