### PR TITLE
fix(core/render-biblio): handle authors as string instead of array

### DIFF
--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -241,6 +241,12 @@ function stringifyReference(ref) {
   output = ref.href ? `<a href="${ref.href}">${output}</a>. ` : `${output}. `;
 
   if (ref.authors && ref.authors.length) {
+    if (!Array.isArray(ref.authors)) {
+      const msg = `The "authors" field in reference "${ref.id || ref.title}" must be an array.`;
+      const hint = `Use \`authors: ["${ref.authors}"]\` instead of \`authors: "${ref.authors}"\`.`;
+      showError(msg, name, { hint });
+      ref.authors = [ref.authors];
+    }
     output += ref.authors.join("; ");
     if (ref.etAl) output += " et al";
     if (!output.endsWith(".")) output += ". ";

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -240,17 +240,18 @@ function stringifyReference(ref) {
 
   output = ref.href ? `<a href="${ref.href}">${output}</a>. ` : `${output}. `;
 
-  if (ref.authors && ref.authors.length) {
+  if (ref.authors) {
     if (!Array.isArray(ref.authors)) {
       const msg = `The "authors" field in reference "${ref.id || ref.title}" must be an array.`;
-      const safeAuthors = JSON.stringify(String(ref.authors));
-      const hint = `Use \`authors: [${safeAuthors}]\` instead of \`authors: ${safeAuthors}\`.`;
+      const hint = `Use \`authors: [${JSON.stringify(ref.authors)}]\` instead of \`authors: ${JSON.stringify(ref.authors)}\`.`;
       showError(msg, name, { hint });
       ref.authors = [ref.authors];
     }
-    output += ref.authors.join("; ");
-    if (ref.etAl) output += " et al";
-    if (!output.endsWith(".")) output += ". ";
+    if (ref.authors.length) {
+      output += ref.authors.join("; ");
+      if (ref.etAl) output += " et al";
+      if (!output.endsWith(".")) output += ". ";
+    }
   }
   if (ref.publisher) {
     output = `${output} ${endWithDot(ref.publisher)} `;

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -243,7 +243,8 @@ function stringifyReference(ref) {
   if (ref.authors && ref.authors.length) {
     if (!Array.isArray(ref.authors)) {
       const msg = `The "authors" field in reference "${ref.id || ref.title}" must be an array.`;
-      const hint = `Use \`authors: ["${ref.authors}"]\` instead of \`authors: "${ref.authors}"\`.`;
+      const safeAuthors = JSON.stringify(String(ref.authors));
+      const hint = `Use \`authors: [${safeAuthors}]\` instead of \`authors: ${safeAuthors}\`.`;
       showError(msg, name, { hint });
       ref.authors = [ref.authors];
     }

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -356,3 +356,29 @@ it("allows custom content in the references section", async () => {
   expect(normRef.textContent).toContain("Normatieve referenties");
   expect(infoRef.textContent).toContain("Informatieve referenties");
 });
+
+it("handles authors as a string instead of array", async () => {
+  const body = `
+    <section id="conformance">
+      <p>[[StringAuthorRef]]</p>
+    </section>
+  `;
+  const localBiblio = {
+    StringAuthorRef: {
+      title: "String Author Test",
+      href: "https://example.com",
+      authors: "Jane Doe",
+    },
+  };
+  const ops = makeStandardOps({ localBiblio }, body);
+  const doc = await makeRSDoc(ops);
+
+  const ref = doc.querySelector("#bib-stringauthorref + dd");
+  expect(ref).toBeTruthy();
+  expect(ref.textContent).toContain("Jane Doe");
+
+  const errors = doc.respec.errors.filter(e => e.message.includes("authors"));
+  expect(errors).toHaveSize(1);
+  expect(errors[0].message).toContain("must be an array");
+  expect(errors[0].hint).toContain("authors:");
+});

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -310,6 +310,34 @@ describe("W3C — Bibliographic References", () => {
     expect(refs).toHaveSize(1);
     expect(refs[0].textContent).toBe("[dom]");
   });
+
+  it("handles authors as a string instead of array", async () => {
+    const body = `
+      <section id="conformance">
+        <p>[[StringAuthorRef]]</p>
+      </section>
+    `;
+    const localBiblio = {
+      StringAuthorRef: {
+        title: "String Author Test",
+        href: "https://example.com",
+        authors: "Jane Doe",
+      },
+    };
+    const ops = makeStandardOps({ localBiblio }, body);
+    const doc = await makeRSDoc(ops);
+
+    const ref = doc.querySelector("#bib-stringauthorref + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toContain("Jane Doe");
+
+    const errors = doc.respec.errors.filter(
+      e => e.plugin === "core/render-biblio" && e.message.includes('"authors"')
+    );
+    expect(errors).toHaveSize(1);
+    expect(errors[0].message).toContain("must be an array");
+    expect(errors[0].hint).toContain('authors: ["Jane Doe"]');
+  });
 });
 
 it("makes sure references section has expected localization text", async () => {
@@ -355,32 +383,4 @@ it("allows custom content in the references section", async () => {
   expect(pText).toContain("Some descriptive text");
   expect(normRef.textContent).toContain("Normatieve referenties");
   expect(infoRef.textContent).toContain("Informatieve referenties");
-});
-
-it("handles authors as a string instead of array", async () => {
-  const body = `
-    <section id="conformance">
-      <p>[[StringAuthorRef]]</p>
-    </section>
-  `;
-  const localBiblio = {
-    StringAuthorRef: {
-      title: "String Author Test",
-      href: "https://example.com",
-      authors: "Jane Doe",
-    },
-  };
-  const ops = makeStandardOps({ localBiblio }, body);
-  const doc = await makeRSDoc(ops);
-
-  const ref = doc.querySelector("#bib-stringauthorref + dd");
-  expect(ref).toBeTruthy();
-  expect(ref.textContent).toContain("Jane Doe");
-
-  const errors = doc.respec.errors.filter(
-    e => e.plugin === "core/render-biblio" && e.message.includes('"authors"')
-  );
-  expect(errors).toHaveSize(1);
-  expect(errors[0].message).toContain("must be an array");
-  expect(errors[0].hint).toContain('authors: ["Jane Doe"]');
 });

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -377,8 +377,10 @@ it("handles authors as a string instead of array", async () => {
   expect(ref).toBeTruthy();
   expect(ref.textContent).toContain("Jane Doe");
 
-  const errors = doc.respec.errors.filter(e => e.message.includes("authors"));
+  const errors = doc.respec.errors.filter(
+    e => e.plugin === "core/render-biblio" && e.message.includes('"authors"')
+  );
   expect(errors).toHaveSize(1);
   expect(errors[0].message).toContain("must be an array");
-  expect(errors[0].hint).toContain("authors:");
+  expect(errors[0].hint).toContain('authors: ["Jane Doe"]');
 });


### PR DESCRIPTION
When localBiblio has authors as a string instead of an array, the join() call crashes and the entire reference section fails to render. Now shows an error with a helpful hint, and auto-corrects to an array so rendering continues.

Closes #4237