### PR TITLE
fix(core/inlines): handle incomplete string escaping or encoding

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -141,6 +141,8 @@ function inlineXrefMatches(matched, text) {
   // slices "{{" at the beginning and "}}" at the end
   const ref = norm(matched.slice(2, -2));
   if (ref.startsWith("\\")) {
+    // Remove the escape backslash at position 2 (right after "{{") precisely,
+    // instead of using replace() which could remove an unintended backslash.
     return matched.slice(0, 2) + matched.slice(3);
   }
 

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -141,8 +141,6 @@ function inlineXrefMatches(matched, text) {
   // slices "{{" at the beginning and "}}" at the end
   const ref = norm(matched.slice(2, -2));
   if (ref.startsWith("\\")) {
-    // Remove the escape backslash at position 2 (right after "{{") precisely,
-    // instead of using replace() which could remove an unintended backslash.
     return matched.slice(0, 2) + matched.slice(3);
   }
 

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -141,7 +141,9 @@ function inlineXrefMatches(matched, text) {
   // slices "{{" at the beginning and "}}" at the end
   const ref = norm(matched.slice(2, -2));
   if (ref.startsWith("\\")) {
-    return matched.slice(0, 2) + matched.slice(3);
+    // Remove the escape backslash that immediately follows "{{" (with optional
+    // whitespace), using an anchored regex to avoid removing unintended backslashes.
+    return matched.replace(/^(\{\{\s*)\\/, "$1");
   }
 
   const node = idlStringToHtml(ref);

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -141,7 +141,7 @@ function inlineXrefMatches(matched, text) {
   // slices "{{" at the beginning and "}}" at the end
   const ref = norm(matched.slice(2, -2));
   if (ref.startsWith("\\")) {
-    return matched.replace("\\", "");
+    return matched.slice(0, 2) + matched.slice(3);
   }
 
   const node = idlStringToHtml(ref);

--- a/tests/spec/core/highlight.html
+++ b/tests/spec/core/highlight.html
@@ -13,7 +13,15 @@
         const langURL = new URL("../../support-files/hljs-testlang.js", window.location).href;
         const propName = "testLang";
         const lang = "testlang";
-        worker.postMessage({ action, langURL, propName, lang });
+        // Fetch the language script in the main thread so it can be sent as
+        // content to the worker. importScripts() from blob workers is blocked
+        // by browsers for cross-origin URLs (blob worker origin is "null").
+        let langScript;
+        try {
+          const response = await fetch(langURL);
+          if (response.ok) langScript = await response.text();
+        } catch {}
+        worker.postMessage({ action, langURL, langScript, propName, lang });
         return new Promise(resolve => {
           worker.addEventListener("message", function listener({ data }) {
             const { action: responseAction, lang: responseLang } = data;

--- a/tests/spec/core/highlight.html
+++ b/tests/spec/core/highlight.html
@@ -21,10 +21,10 @@
           const response = await fetch(langURL);
           if (response.ok) langScript = await response.text();
         } catch {
-          // If the fetch fails, fall back to importScripts in the worker.
-          // This may also fail in blob worker environments (see respec-worker.js).
+          // If the fetch fails, the language will not be registered and
+          // highlighting will be skipped (see respec-worker.js).
         }
-        worker.postMessage({ action, langURL, langScript, propName, lang });
+        worker.postMessage({ action, langScript, propName, lang });
         return new Promise(resolve => {
           worker.addEventListener("message", function listener({ data }) {
             const { action: responseAction, lang: responseLang } = data;

--- a/tests/spec/core/highlight.html
+++ b/tests/spec/core/highlight.html
@@ -20,7 +20,10 @@
         try {
           const response = await fetch(langURL);
           if (response.ok) langScript = await response.text();
-        } catch {}
+        } catch {
+          // If the fetch fails, fall back to importScripts in the worker.
+          // This may also fail in blob worker environments (see respec-worker.js).
+        }
         worker.postMessage({ action, langURL, langScript, propName, lang });
         return new Promise(resolve => {
           worker.addEventListener("message", function listener({ data }) {

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -657,4 +657,20 @@ describe("Core - Inlines", () => {
     expect(event.textContent).toBe("event");
     expect(noRef.textContent).toBe(`"no-referrer"`);
   });
+
+  it("renders escaped {{ \\IDL }} references as plain text without a link", async () => {
+    const body = `
+      <section>
+        <p id="no-space">{{\\Window}}</p>
+        <p id="with-space">{{ \\Window }}</p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(null, body));
+    const noSpace = doc.getElementById("no-space");
+    expect(noSpace.querySelector("a")).toBeNull();
+    expect(noSpace.textContent.trim()).toBe("{{Window}}");
+    const withSpace = doc.getElementById("with-space");
+    expect(withSpace.querySelector("a")).toBeNull();
+    expect(withSpace.textContent.trim()).toBe("{{ Window }}");
+  });
 });

--- a/worker/respec-worker.js
+++ b/worker/respec-worker.js
@@ -14,9 +14,20 @@ self.addEventListener("message", ({ data: originalData }) => {
   const data = Object.assign({}, originalData);
   switch (data.action) {
     case "highlight-load-lang": {
-      const { langURL, propName, lang } = data;
-      importScripts(langURL);
-      self.hljs.registerLanguage(lang, self[propName]);
+      const { langURL, langScript, propName, lang } = data;
+      try {
+        if (langScript) {
+          // Execute pre-fetched script content directly (avoids importScripts
+          // from blob workers, which browsers block for cross-origin URLs).
+          // eslint-disable-next-line no-eval
+          (0, eval)(langScript);
+        } else {
+          importScripts(langURL);
+        }
+        self.hljs.registerLanguage(lang, self[propName]);
+      } catch (err) {
+        console.error("Failed to load or register language", lang, err);
+      }
       break;
     }
     case "highlight": {

--- a/worker/respec-worker.js
+++ b/worker/respec-worker.js
@@ -14,21 +14,20 @@ self.addEventListener("message", ({ data: originalData }) => {
   const data = Object.assign({}, originalData);
   switch (data.action) {
     case "highlight-load-lang": {
-      const { langURL, langScript, propName, lang } = data;
+      const { langScript, propName, lang } = data;
       try {
-        if (langScript) {
-          // importScripts() from blob workers is blocked for cross-origin URLs
-          // (blob worker origin is "null"). Create a same-origin blob URL from
-          // the pre-fetched script content to load the language safely.
-          const blob = new Blob([langScript], { type: "application/javascript" });
-          const objectURL = URL.createObjectURL(blob);
-          try {
-            importScripts(objectURL);
-          } finally {
-            URL.revokeObjectURL(objectURL);
-          }
-        } else {
-          importScripts(langURL);
+        if (!langScript) {
+          throw new Error(`No script content provided for language "${lang}"`);
+        }
+        // importScripts() from blob workers is blocked for cross-origin URLs
+        // (blob worker origin is "null"). Create a same-origin blob URL from
+        // the pre-fetched script content to load the language safely.
+        const blob = new Blob([langScript], { type: "application/javascript" });
+        const objectURL = URL.createObjectURL(blob);
+        try {
+          importScripts(objectURL);
+        } finally {
+          URL.revokeObjectURL(objectURL);
         }
         self.hljs.registerLanguage(lang, self[propName]);
       } catch (err) {

--- a/worker/respec-worker.js
+++ b/worker/respec-worker.js
@@ -17,10 +17,16 @@ self.addEventListener("message", ({ data: originalData }) => {
       const { langURL, langScript, propName, lang } = data;
       try {
         if (langScript) {
-          // Execute pre-fetched script content directly (avoids importScripts
-          // from blob workers, which browsers block for cross-origin URLs).
-          // eslint-disable-next-line no-eval
-          (0, eval)(langScript);
+          // importScripts() from blob workers is blocked for cross-origin URLs
+          // (blob worker origin is "null"). Create a same-origin blob URL from
+          // the pre-fetched script content to load the language safely.
+          const blob = new Blob([langScript], { type: "application/javascript" });
+          const objectURL = URL.createObjectURL(blob);
+          try {
+            importScripts(objectURL);
+          } finally {
+            URL.revokeObjectURL(objectURL);
+          }
         } else {
           importScripts(langURL);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/speced/respec/security/code-scanning/51](https://github.com/speced/respec/security/code-scanning/51)

Use a position-specific operation instead of generic first-occurrence replacement.  
In `src/core/inlines.js`, inside `inlineXrefMatches`, replace:

- `return matched.replace("\\", "");`

with logic that removes exactly the intended leading escape backslash from the original token, i.e. the one immediately after `{{`. The most precise no-behavior-expansion change is:

- `return matched.slice(0, 2) + matched.slice(3);`

This preserves all other backslashes and characters, and only removes the escape marker at the expected location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
