### PR TITLE
fix(core/data-abbr): DOM text reinterpreted as HTML

### DIFF
--- a/src/core/data-abbr.js
+++ b/src/core/data-abbr.js
@@ -33,11 +33,7 @@ function processDfnElement(dfn) {
   const abbrEl = document.createElement("abbr");
   abbrEl.title = fullForm;
   abbrEl.textContent = abbr;
-  dfn.after(
-    document.createTextNode(" ("),
-    abbrEl,
-    document.createTextNode(")")
-  );
+  dfn.after(" (", abbrEl, ")");
   const lt = dfn.dataset.lt || "";
   dfn.dataset.lt = lt
     .split("|")

--- a/tests/spec/core/data-abbr-spec.js
+++ b/tests/spec/core/data-abbr-spec.js
@@ -92,4 +92,17 @@ describe("Core — data-abbr", () => {
     const abbr = doc.querySelector("section abbr");
     expect(abbr.title).toBe("Permanent Account Number");
   });
+  it("safely handles HTML-special characters in dfn text", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      body: `<section id="section">
+        <dfn data-abbr="T&amp;C">Terms &amp; "Conditions"</dfn>
+      </section>`,
+    };
+    const doc = await makeRSDoc(ops);
+    const abbr = doc.querySelector("#section dfn + abbr");
+    expect(abbr).toBeTruthy();
+    expect(abbr.title).toBe('Terms & "Conditions"');
+    expect(abbr.textContent).toBe("T&C");
+  });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/speced/respec/security/code-scanning/5](https://github.com/speced/respec/security/code-scanning/5)

Use DOM APIs to construct nodes and set text/attributes directly instead of `insertAdjacentHTML`. This preserves existing behavior while preventing HTML reinterpretation.

Best fix in `src/core/data-abbr.js`:
- In `processDfnElement`, replace the `insertAdjacentHTML` call (lines 33–36 region) with:
  - `document.createTextNode(" (")`
  - `document.createElement("abbr")`
  - set `abbrElem.title = fullForm`
  - set `abbrElem.textContent = abbr`
  - `document.createTextNode(")")`
  - insert these nodes after `dfn` in order.
- This removes the HTML sink entirely and addresses both variants, including taint from `generateAbbreviation`/`elem.textContent`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
