### PR TITLE
fix(core/highlight): use textContent instead of innerText

### DIFF
--- a/src/core/highlight.js
+++ b/src/core/highlight.js
@@ -23,7 +23,7 @@ async function highlightElement(elem) {
   const languages = getLanguageHint(elem.classList);
   let response;
   try {
-    response = await sendHighlightRequest(elem.innerText, languages);
+    response = await sendHighlightRequest(elem.textContent, languages);
   } catch (err) {
     console.error(err);
     return;


### PR DESCRIPTION
## Summary

`innerText` returns empty for content inside closed `<details>` elements because it reads only rendered (visible) text. `textContent` reads the DOM regardless of visibility, so syntax highlighting now works inside `<details>`.

One-line change in `highlightElement()`.

Fixes #4695

## Test plan

- [x] 8 highlight tests pass
- [x] ESLint clean
- [x] ~~Modified Web platform tests~~ — browser behaviour fix in ReSpec, no WPT scope