### PR TITLE
fix(core): Do not add `role=heading` to issue/note title elements

### DIFF
--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -11,13 +11,7 @@
 // numbered to avoid involuntary clashes.
 // If the configuration has issueBase set to a non-empty string, and issues are
 // manually numbered, a link to the issue is created using issueBase and the issue number
-import {
-  addId,
-  getIntlData,
-  parents,
-  showError,
-  showWarning,
-} from "./utils.js";
+import { addId, getIntlData, showError, showWarning } from "./utils.js";
 import css from "../styles/issues-notes.css.js";
 import { html } from "./import-maps.js";
 export const name = "core/issues-notes";
@@ -129,7 +123,7 @@ function handleIssues(ins, ghIssues, conf) {
       const title = document.createElement("span");
       const className = `${type}-title marker`;
       // prettier-ignore
-      const titleParent = html`<div role="heading" class="${className}">${title}</div>`;
+      const titleParent = html`<div class="${className}">${title}</div>`;
       addId(titleParent, "h", type);
       let text = displayType;
       if (inno.id) {
@@ -189,8 +183,6 @@ function handleIssues(ins, ghIssues, conf) {
           .createContextualFragment(ghIssue.bodyHTML);
       }
       div.append(titleParent, body);
-      const level = parents(titleParent, "section").length + 2;
-      titleParent.setAttribute("aria-level", level);
     }
   });
   makeIssueSectionSummary(issueList);

--- a/tests/spec/core/issues-notes-spec.js
+++ b/tests/spec/core/issues-notes-spec.js
@@ -115,6 +115,27 @@ describe("Core — Issues and Notes", () => {
     expect(pnot.textContent).toBe("EDNOTE");
   });
 
+  it("should not treat titles of issues, notes, or ednotes as headings", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      body:
+        `${makeDefaultBody()}<section id="test">` +
+        `<p class='issue' title='ISS-TIT'>ISSUE</p>` +
+        `<p class='note' title='NOT-TIT'>NOTE</p>` +
+        `<p class='ednote' title='EDNOTE-TIT'>EDNOTE</p>` +
+        `</section>`,
+    };
+    const doc = await makeRSDoc(ops);
+    const issueTitle = doc.querySelector("div.issue div.issue-title");
+    const noteTitle = doc.querySelector("div.note div.note-title");
+    const ednoteTitle = doc.querySelector("div.note div.ednote-title");
+
+    for (const title of [issueTitle, noteTitle, ednoteTitle]) {
+      expect(title.getAttribute("role")).toBeNull();
+      expect(title.getAttribute("aria-level")).toBeNull();
+    }
+  });
+
   it("should process warnings", async () => {
     const ops = {
       config: makeBasicConfig(),


### PR DESCRIPTION
Resolves #5092
Closes #1752
Closes #4274
Closes #4789

I created the referenced issue 4 months ago; please see its description for more detailed rationale. As the issue did not receive any further input and the WAI Team is still interested in resolving it, I have gone ahead and created this pull request that would do so.

I could not find any tests verifying the existing behavior; none were added in #1400 where the behavior was introduced. IMO adding negative tests now for its removal would seem superfluous. I verified locally that the `role` and `aria-level` attributes are no longer added with this change.

Also note related issues in #5092's description that I believe could be closed as no longer applicable if this is merged.