### PR TITLE
fix(core/xref): normalize versioned spec names in data-cite context

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -210,6 +210,29 @@ export function getTermFromElement(elem) {
 }
 
 /**
+ * @param {string} spec
+ */
+function stripVersionSuffix(spec) {
+  return spec.replace(/-\d+$/, "");
+}
+
+/**
+ * Expands versioned spec names to include the unversioned form.
+ * E.g., ["service-workers-1"] becomes ["service-workers-1", "service-workers"].
+ * @param {string[]} specs
+ */
+function expandVersionedSpecs(specs) {
+  return [
+    ...new Set(
+      specs.flatMap(s => {
+        const stripped = stripVersionSuffix(s);
+        return stripped !== s ? [s, stripped] : [s];
+      })
+    ),
+  ];
+}
+
+/**
  * Get spec context as a fallback chain, where each level (sub-array) represents
  * decreasing priority.
  * @param {HTMLElement} elem
@@ -226,7 +249,7 @@ function getSpecContext(elem) {
     const cite = (dataciteElem.dataset.cite ?? "")
       .toLowerCase()
       .replace(/[!?]/g, "");
-    const cites = cite.split(/\s+/).filter(s => s);
+    const cites = expandVersionedSpecs(cite.split(/\s+/).filter(s => s));
     if (cites.length) {
       specs.push(cites);
     }
@@ -242,7 +265,9 @@ function getSpecContext(elem) {
     const bibrefs = closestSection
       ? closestSection.querySelectorAll("a.bibref")
       : [];
-    const inlineRefs = [...bibrefs].map(el => el.textContent.toLowerCase());
+    const inlineRefs = expandVersionedSpecs(
+      [...bibrefs].map(el => el.textContent.toLowerCase())
+    );
     if (inlineRefs.length) {
       specs.push(inlineRefs);
     }
@@ -500,7 +525,13 @@ function showErrors({ ambiguous, notFound }) {
     const originalTerm = getTermFromElement(elems[0]);
     const formUrl = getPrefilledFormURL(originalTerm, query);
     const specsString = joinAnd(specs, s => `**[${s}]**`);
-    const hint = howToFix(formUrl, originalTerm);
+    let hint = howToFix(formUrl, originalTerm);
+    /** @type {HTMLElement | null} */
+    const closestCite = elems[0].closest("[data-cite]");
+    if (closestCite && closestCite !== document.body) {
+      const citeAttr = (closestCite.dataset.cite ?? "").replace(/`/g, "");
+      hint += ` A parent element has \`data-cite="${citeAttr}"\` — check that the spec shortname is correct.`;
+    }
     const forParent = query.for ? `, for **"${query.for}"**, ` : "";
     const msg = `Couldn't find "**${originalTerm}**"${forParent} in this document or other cited documents: ${specsString}.`;
     const title = "No matching definition found.";

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -217,24 +217,16 @@ function stripVersionSuffix(spec) {
 }
 
 /**
- * Expands versioned spec names to include the unversioned form.
- * E.g., ["service-workers-1"] becomes ["service-workers-1", "service-workers"].
- * @param {string[]} specs
- */
-function expandVersionedSpecs(specs) {
-  return [
-    ...new Set(
-      specs.flatMap(s => {
-        const stripped = stripVersionSuffix(s);
-        return stripped !== s ? [s, stripped] : [s];
-      })
-    ),
-  ];
-}
-
-/**
  * Get spec context as a fallback chain, where each level (sub-array) represents
  * decreasing priority.
+ *
+ * For versioned spec names (e.g. "service-workers-1"), the unversioned form
+ * ("service-workers") is added as a **separate lower-priority level** rather
+ * than at the same level.  Keeping them at different levels avoids returning
+ * two results for the same term when the xref data indexes the definition under
+ * both the versioned and unversioned shortname, which would otherwise trigger a
+ * spurious "ambiguous dfn" error.
+ *
  * @param {HTMLElement} elem
  */
 function getSpecContext(elem) {
@@ -249,9 +241,23 @@ function getSpecContext(elem) {
     const cite = (dataciteElem.dataset.cite ?? "")
       .toLowerCase()
       .replace(/[!?]/g, "");
-    const cites = expandVersionedSpecs(cite.split(/\s+/).filter(s => s));
+    const cites = cite.split(/\s+/).filter(s => s);
     if (cites.length) {
       specs.push(cites);
+      // Add the unversioned forms (e.g. "service-workers" for "service-workers-1")
+      // at a lower priority so the server only falls back to them when the
+      // versioned name yields no result.  This prevents ambiguous-dfn errors if
+      // a term is indexed under both shortname variants.
+      const unversioned = [
+        ...new Set(
+          cites
+            .map(stripVersionSuffix)
+            .filter((stripped, i) => stripped !== cites[i])
+        ),
+      ];
+      if (unversioned.length) {
+        specs.push(unversioned);
+      }
     }
     if (dataciteElem === elem) break;
     dataciteElem = dataciteElem.parentElement?.closest("[data-cite]") ?? null;
@@ -265,11 +271,22 @@ function getSpecContext(elem) {
     const bibrefs = closestSection
       ? closestSection.querySelectorAll("a.bibref")
       : [];
-    const inlineRefs = expandVersionedSpecs(
-      [...bibrefs].map(el => el.textContent.toLowerCase())
-    );
-    if (inlineRefs.length) {
-      specs.push(inlineRefs);
+    const inlineRefList = [
+      ...new Set([...bibrefs].map(el => el.textContent.toLowerCase())),
+    ];
+    if (inlineRefList.length) {
+      specs.push(inlineRefList);
+      // Same versioned → unversioned fallback for inline bibrefs.
+      const unversioned = [
+        ...new Set(
+          inlineRefList
+            .map(stripVersionSuffix)
+            .filter((stripped, i) => stripped !== inlineRefList[i])
+        ),
+      ];
+      if (unversioned.length) {
+        specs.push(unversioned);
+      }
     }
   }
 
@@ -285,11 +302,11 @@ function getSpecContext(elem) {
 function dedupeSpecContext(specs) {
   /** @type {string[][]} */
   const unique = [];
+  /** @type {Set<string>} tracks all specs seen in higher-priority levels */
+  const seen = new Set();
   for (const level of specs) {
-    const higherPriority = unique[unique.length - 1] || [];
-    const uniqueSpecs = [...new Set(level)].filter(
-      spec => !higherPriority.includes(spec)
-    );
+    const uniqueSpecs = [...new Set(level)].filter(spec => !seen.has(spec));
+    uniqueSpecs.forEach(s => seen.add(s));
     unique.push(uniqueSpecs.sort());
   }
   return unique;

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -249,11 +249,7 @@ function getSpecContext(elem) {
       // versioned name yields no result.  This prevents ambiguous-dfn errors if
       // a term is indexed under both shortname variants.
       const unversioned = [
-        ...new Set(
-          cites
-            .map(stripVersionSuffix)
-            .filter((stripped, i) => stripped !== cites[i])
-        ),
+        ...new Set(cites.map(stripVersionSuffix)).difference(new Set(cites)),
       ];
       if (unversioned.length) {
         specs.push(unversioned);
@@ -278,10 +274,8 @@ function getSpecContext(elem) {
       specs.push(inlineRefList);
       // Same versioned → unversioned fallback for inline bibrefs.
       const unversioned = [
-        ...new Set(
-          inlineRefList
-            .map(stripVersionSuffix)
-            .filter((stripped, i) => stripped !== inlineRefList[i])
+        ...new Set(inlineRefList.map(stripVersionSuffix)).difference(
+          new Set(inlineRefList)
         ),
       ];
       if (unversioned.length) {

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -527,9 +527,9 @@ function showErrors({ ambiguous, notFound }) {
     const specsString = joinAnd(specs, s => `**[${s}]**`);
     let hint = howToFix(formUrl, originalTerm);
     /** @type {HTMLElement | null} */
-    const closestCite = elems[0].closest("[data-cite]");
-    if (closestCite && closestCite !== document.body) {
-      const citeAttr = (closestCite.dataset.cite ?? "").replace(/`/g, "");
+    const closestCite = elems[0].parentElement?.closest("[data-cite]") ?? null;
+    const citeAttr = closestCite?.dataset.cite?.replace(/`/g, "") ?? "";
+    if (closestCite && closestCite !== document.body && citeAttr) {
       hint += ` A parent element has \`data-cite="${citeAttr}"\` — check that the spec shortname is correct.`;
     }
     const forParent = query.for ? `, for **"${query.for}"**, ` : "";

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -248,9 +248,7 @@ function getSpecContext(elem) {
       // at a lower priority so the server only falls back to them when the
       // versioned name yields no result.  This prevents ambiguous-dfn errors if
       // a term is indexed under both shortname variants.
-      const unversioned = [
-        ...new Set(cites.map(stripVersionSuffix)).difference(new Set(cites)),
-      ];
+      const unversioned = getUnversionedFallbacks(cites);
       if (unversioned.length) {
         specs.push(unversioned);
       }
@@ -272,12 +270,7 @@ function getSpecContext(elem) {
     ];
     if (inlineRefList.length) {
       specs.push(inlineRefList);
-      // Same versioned → unversioned fallback for inline bibrefs.
-      const unversioned = [
-        ...new Set(inlineRefList.map(stripVersionSuffix)).difference(
-          new Set(inlineRefList)
-        ),
-      ];
+      const unversioned = getUnversionedFallbacks(inlineRefList);
       if (unversioned.length) {
         specs.push(unversioned);
       }
@@ -286,6 +279,15 @@ function getSpecContext(elem) {
 
   const uniqueSpecContext = dedupeSpecContext(specs);
   return uniqueSpecContext;
+}
+
+/**
+ * Returns specs whose unversioned form differs from the original,
+ * e.g., ["css-grid-2"] → ["css-grid"] (excluding "css-grid-2" itself).
+ * @param {string[]} specs
+ */
+function getUnversionedFallbacks(specs) {
+  return [...new Set(specs.map(stripVersionSuffix)).difference(new Set(specs))];
 }
 
 /**
@@ -299,7 +301,7 @@ function dedupeSpecContext(specs) {
   /** @type {Set<string>} tracks all specs seen in higher-priority levels */
   const seen = new Set();
   for (const level of specs) {
-    const uniqueSpecs = [...new Set(level)].filter(spec => !seen.has(spec));
+    const uniqueSpecs = [...new Set(level).values().filter(s => !seen.has(s))];
     uniqueSpecs.forEach(s => seen.add(s));
     unique.push(uniqueSpecs.sort());
   }

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import {
+  errorFilters,
   flushIframes,
   makeDefaultBody,
   makeRSDoc,
@@ -259,6 +260,55 @@ describe("Core — xref", () => {
       "#test .respec-offending-element"
     );
     expect(offendingElements).toHaveSize(0);
+  });
+
+  it("strips version suffix from data-cite in spec context", async () => {
+    const body = `
+      <section data-cite="service-workers-1" id="test">
+        <p><a id="link">service worker</a></p>
+      </section>
+    `;
+    const config = { xref: true, localBiblio };
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    const link = doc.getElementById("link");
+    expect(link.classList).not.toContain("respec-offending-element");
+    expect(link.href).toContain("service-workers");
+  });
+
+  it("resolves terms with unversioned data-cite on container", async () => {
+    const body = `
+      <section data-cite="service-workers" id="test">
+        <p><a id="link">service worker</a></p>
+      </section>
+    `;
+    const config = { xref: true, localBiblio };
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    const link = doc.getElementById("link");
+    expect(link.classList).not.toContain("respec-offending-element");
+    expect(link.href).toContain("service-workers");
+  });
+
+  it("shows data-cite hint in error when spec shortname is wrong", async () => {
+    const errors = errorFilters.filter("core/xref");
+    const body = `
+      <section data-cite="service-workerz" id="test">
+        <p><a id="link">service worker</a></p>
+      </section>
+    `;
+    const config = { xref: true, localBiblio };
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    const link = doc.getElementById("link");
+    expect(link.classList).toContain("respec-offending-element");
+    const xrefErrors = errors(doc);
+    const error = xrefErrors.find(e => e.message.includes("service worker"));
+    expect(error).toBeTruthy();
+    expect(error.hint).toContain('data-cite="service-workerz"');
   });
 
   it("ignores terms if local dfn exists", async () => {

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -263,6 +263,12 @@ describe("Core — xref", () => {
   });
 
   it("strips version suffix from data-cite in spec context", async () => {
+    // Regression test for https://github.com/speced/respec/issues/5224.
+    // Using a versioned shortname (e.g. SERVICE-WORKERS-1) must:
+    //   1. still resolve the term (unversioned fallback is used if needed), and
+    //   2. NOT produce an "ambiguous dfn" error even if the xref data indexes
+    //      the definition under both the versioned and unversioned shortname.
+    const errors = errorFilters.filter("core/xref");
     const body = `
       <section data-cite="service-workers-1" id="test">
         <p><a id="link">service worker</a></p>
@@ -275,6 +281,11 @@ describe("Core — xref", () => {
     const link = doc.getElementById("link");
     expect(link.classList).not.toContain("respec-offending-element");
     expect(link.href).toContain("service-workers");
+    // Confirm neither an "ambiguous" nor a "not found" error was raised.
+    const xrefErrors = errors(doc);
+    expect(
+      xrefErrors.filter(e => e.message.includes("service worker"))
+    ).toEqual([]);
   });
 
   it("resolves terms with unversioned data-cite on container", async () => {


### PR DESCRIPTION
Closes #5224

`getSpecContext()` in `xref.js` only lowercased spec names from `data-cite` attributes — it did no version-suffix normalization. So `data-cite="SERVICE-WORKERS-1"` became `service-workers-1`, which the xref API couldn't match via its `shortname` field (`service-workers`).

The fix expands each versioned spec name (matching `-\d+$`) to include both the original and the unversioned form in the same priority level. This preserves the versioned form for correct biblio resolution while also enabling shortname matching on the server.

Additionally, the "term not found" error hint now shows the raw `data-cite` value when the failing element has a local `data-cite` ancestor, so authors can spot spec shortname typos immediately.