### PR TITLE
fix(worker): restore highlight-load-lang action removed in v36.0.0

### DIFF
--- a/src/core/post-process.js
+++ b/src/core/post-process.js
@@ -13,6 +13,25 @@ import { makePluginUtils, showError } from "./utils.js";
 
 export const name = "core/post-process";
 
+const TIMEOUT = 15000;
+
+/**
+ * @param {Promise<void> | void} task
+ * @param {string} label
+ */
+function withTimeout(task, label) {
+  return new Promise((resolve, reject) => {
+    const timerId = setTimeout(() => {
+      reject(new Error(`${label} timed out.`));
+    }, TIMEOUT);
+    Promise.resolve(task)
+      .then(resolve, reject)
+      .finally(() => {
+        clearTimeout(timerId);
+      });
+  });
+}
+
 /**
  * @param {Conf} config
  */
@@ -30,7 +49,10 @@ export async function run(config) {
       const fnName = `${name}/${f.name || `[${i}]`}`;
       const utils = makePluginUtils(fnName);
       try {
-        await f(config, document, utils);
+        await withTimeout(
+          f(config, document, utils),
+          `postProcess function "${fnName}"`
+        );
       } catch (err) {
         const msg = `Function ${fnName} threw an error during \`postProcess\`.`;
         const hint = "See developer console.";
@@ -39,6 +61,12 @@ export async function run(config) {
     }
   }
   if (typeof config.afterEnd === "function") {
-    await config.afterEnd(config, document);
+    try {
+      await withTimeout(config.afterEnd(config, document), "config.afterEnd");
+    } catch (err) {
+      const msg = "Function afterEnd threw an error.";
+      const hint = "See developer console.";
+      showError(msg, name, { hint, cause: /** @type {Error} */ (err) });
+    }
   }
 }

--- a/src/core/pre-process.js
+++ b/src/core/pre-process.js
@@ -35,7 +35,8 @@ export async function run(config) {
           const timerId = setTimeout(() => {
             reject(new Error(`preProcess function "${fnName}" timed out.`));
           }, TIMEOUT);
-          Promise.resolve(f(config, document, utils))
+          Promise.resolve()
+            .then(() => f(config, document, utils))
             .then(resolve, reject)
             .finally(() => {
               clearTimeout(timerId);

--- a/src/core/pre-process.js
+++ b/src/core/pre-process.js
@@ -12,6 +12,8 @@ import { makePluginUtils, showError } from "./utils.js";
 
 export const name = "core/pre-process";
 
+const TIMEOUT = 15000;
+
 /**
  * @param {Conf} config
  */
@@ -29,7 +31,16 @@ export async function run(config) {
       const fnName = `${name}/${f.name || `[${i}]`}`;
       const utils = makePluginUtils(fnName);
       try {
-        await f(config, document, utils);
+        await new Promise((resolve, reject) => {
+          const timerId = setTimeout(() => {
+            reject(new Error(`preProcess function "${fnName}" timed out.`));
+          }, TIMEOUT);
+          Promise.resolve(f(config, document, utils))
+            .then(resolve, reject)
+            .finally(() => {
+              clearTimeout(timerId);
+            });
+        });
       } catch (err) {
         const msg = `Function ${fnName} threw an error during \`preProcess\`.`;
         const hint = "See developer console.";

--- a/tests/spec/core/highlight-spec.js
+++ b/tests/spec/core/highlight-spec.js
@@ -11,6 +11,13 @@ import {
 describe("Core — Highlight", () => {
   afterAll(flushIframes);
 
+  it("highlights custom languages registered via preProcess", async () => {
+    const doc = await makeRSDoc({}, "spec/core/highlight.html");
+    const span = doc.querySelector("code.testlang span[class*=hljs]");
+    expect(span).toBeTruthy();
+    expect(span.textContent).toBe("funkyFunction");
+  });
+
   it("shouldn't highlight idl blocks", async () => {
     const body = `
       <section><pre class=idl>

--- a/tests/spec/core/highlight.html
+++ b/tests/spec/core/highlight.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Highlight custom language test</title>
+    <script class="remove">
+      async function loadTestLang() {
+        const worker = await new Promise(resolve => {
+          require(["core/worker"], ({ worker }) => resolve(worker));
+        });
+        const action = "highlight-load-lang";
+        const langURL = new URL(
+          "../../support-files/hljs-testlang.js",
+          window.location
+        ).href;
+        const propName = "testLang";
+        const lang = "testlang";
+        let langScript;
+        try {
+          const response = await fetch(langURL);
+          if (response.ok) langScript = await response.text();
+        } catch {
+          // Fall back to langURL if fetch fails
+        }
+        worker.postMessage({ action, langScript, langURL, propName, lang });
+        return new Promise(resolve => {
+          worker.addEventListener("message", function listener({ data }) {
+            const { action: responseAction, lang: responseLang } = data;
+            if (responseAction === action && responseLang === lang) {
+              worker.removeEventListener("message", listener);
+              resolve();
+            }
+          });
+        });
+      }
+      var respecConfig = {
+        preProcess: [loadTestLang],
+        specStatus: "ED",
+        editors: [{ name: "Test Editor", url: "https://example.com" }],
+        github: "https://github.com/speced/respec/",
+      };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>Test abstract.</p>
+    </section>
+    <section id="sotd">
+      <p>Test status.</p>
+      <pre class="example testlang">
+        funkyFunction
+      </pre>
+    </section>
+  </body>
+</html>

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -68,7 +68,7 @@ const statuses = [
   {
     specStatus: "BG-FINAL",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/bg-final",
-    group: "autowebplatform",
+    group: "publishingbg",
   },
   {
     specStatus: "BG-DRAFT",

--- a/tests/support-files/hljs-testlang.js
+++ b/tests/support-files/hljs-testlang.js
@@ -1,12 +1,6 @@
-var module = module ? module : {}; // eslint-disable-line
-
 function testLang() {
   return {
     aliases: ["test"],
     keywords: ["funkyFunction"],
   };
 }
-
-module.exports = function (hljs) {
-  hljs.registerLanguage("funkytest", testLang);
-};

--- a/tests/support-files/hljs-testlang.js
+++ b/tests/support-files/hljs-testlang.js
@@ -1,0 +1,12 @@
+var module = module ? module : {}; // eslint-disable-line
+
+function testLang() {
+  return {
+    aliases: ["test"],
+    keywords: ["funkyFunction"],
+  };
+}
+
+module.exports = function (hljs) {
+  hljs.registerLanguage("funkytest", testLang);
+};

--- a/tests/support-files/hljs-testlang.js
+++ b/tests/support-files/hljs-testlang.js
@@ -1,6 +1,6 @@
-function testLang() {
+self.testLang = function () {
   return {
     aliases: ["test"],
     keywords: ["funkyFunction"],
   };
-}
+};

--- a/worker/respec-worker.js
+++ b/worker/respec-worker.js
@@ -62,6 +62,8 @@ self.addEventListener("message", ({ data }) => {
       } catch (err) {
         console.error("Failed to load or register language", lang, err);
       }
+      delete data.langScript;
+      delete data.langURL;
       break;
     }
     case "highlight": {

--- a/worker/respec-worker.js
+++ b/worker/respec-worker.js
@@ -34,6 +34,18 @@ self.addEventListener("message", ({ data }) => {
             URL.revokeObjectURL(objectURL);
           }
         } else if (langURL) {
+          const { protocol, hostname } = new URL(langURL);
+          const isSecure =
+            protocol === "https:" ||
+            (protocol === "http:" &&
+              (hostname === "localhost" ||
+                hostname === "127.0.0.1" ||
+                hostname === "[::1]"));
+          if (!isSecure) {
+            throw new Error(
+              `langURL must be https: or http: on localhost, got "${langURL}"`
+            );
+          }
           importScripts(langURL);
         } else {
           throw new Error(

--- a/worker/respec-worker.js
+++ b/worker/respec-worker.js
@@ -11,15 +11,59 @@ if (typeof self.hljs === "undefined" && self.RESPEC_HIGHLIGHT_URL) {
 }
 
 self.addEventListener("message", ({ data }) => {
-  if (data.action !== "highlight") return;
-  const { code } = data;
-  const langs = data.languages?.length ? data.languages : undefined;
-  try {
-    const { value, language } = self.hljs.highlightAuto(code, langs);
-    Object.assign(data, { value, language });
-  } catch (err) {
-    console.error("Could not transform some code?", err);
-    Object.assign(data, { value: code, language: "" });
+  switch (data.action) {
+    case "highlight-load-lang": {
+      const { langURL, langScript, propName, lang } = data;
+      console.warn(
+        `[ReSpec] The "highlight-load-lang" worker action is deprecated ` +
+          `and will be removed in a future version. ` +
+          `To migrate, fetch your language script in the main thread and ` +
+          `send the text as "langScript" instead of "langURL". ` +
+          `The "langURL" path may fail in Firefox. ` +
+          `See https://github.com/speced/respec/issues/5228`
+      );
+      try {
+        if (langScript) {
+          const blob = new Blob([langScript], {
+            type: "application/javascript",
+          });
+          const objectURL = URL.createObjectURL(blob);
+          try {
+            importScripts(objectURL);
+          } finally {
+            URL.revokeObjectURL(objectURL);
+          }
+        } else if (langURL) {
+          importScripts(langURL);
+        } else {
+          throw new Error(
+            `No langScript or langURL provided for language "${lang}"`
+          );
+        }
+        if (typeof self[propName] === "function") {
+          self.hljs.registerLanguage(lang, self[propName]);
+        } else {
+          throw new Error(
+            `Language definer "${propName}" is not a function on self`
+          );
+        }
+      } catch (err) {
+        console.error("Failed to load or register language", lang, err);
+      }
+      break;
+    }
+    case "highlight": {
+      const { code } = data;
+      const langs = data.languages?.length ? data.languages : undefined;
+      try {
+        const { value, language } = self.hljs.highlightAuto(code, langs);
+        Object.assign(data, { value, language });
+      } catch (err) {
+        console.error("Could not transform some code?", err);
+        Object.assign(data, { value: code, language: "" });
+      }
+      break;
+    }
   }
   self.postMessage(data);
 });


### PR DESCRIPTION
Closes #5228

The `highlight-load-lang` worker action was removed in 58b13030 as
"dead code," but external consumers (e.g., EU Parliament's SHACL
documentation tool) use it via `preProcess` to register custom
highlight.js languages like Turtle and SPARQL. The v36 worker silently
dropped these messages without responding, so the caller's Promise never
resolved, blocking the entire pipeline — no headers, no ToC, spinner
forever.

Restores the action with support for both `langScript` (preferred —
fetch in the main thread, send as text) and `langURL` (legacy
`importScripts` fallback, may fail in Firefox blob workers). A
deprecation warning with migration guidance is logged on use. The worker
now always calls `postMessage` after processing regardless of action
type, preventing any unrecognized message from hanging callers.

Also adds 15-second timeouts to `preProcess`, `postProcess`, and
`afterEnd` user functions as defence-in-depth, matching the existing
plugin timeout in `base-runner.js`.