### PR TITLE
chore(core/implementation-status): add Baseline logo attribution

### DIFF
--- a/src/core/implementation-status.js
+++ b/src/core/implementation-status.js
@@ -3,6 +3,10 @@
  * Module: "core/implementation-status"
  * Adds an implementation status badge to the spec front matter,
  * showing Baseline browser availability from web-features data.
+ *
+ * Baseline name and logos are trademarks of Google LLC, used under
+ * the CC BY-ND 4.0 license. See usage guidelines:
+ * https://web-platform-dx.github.io/web-features/name-and-logo-usage-guidelines/
  */
 import { docLink, fetchAndCache, showWarning } from "./utils.js";
 import { pub, sub } from "./pubsubhub.js";


### PR DESCRIPTION
Adds source-level attribution for the Baseline name and logos per the
CC BY-ND 4.0 license requirements. The rendered output links to
webstatus.dev, which provides user-facing attribution.

See: https://web-platform-dx.github.io/web-features/name-and-logo-usage-guidelines/