### PR TITLE
fix(core/inline-idl-parser): resolve {{[[slot]]}} from ancestor data-link-for

### DIFF
--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -92,7 +92,7 @@ function parseInlineIDL(str) {
   const isSlot = isProbablySlotRegex.test(str);
   const splitter = isSlot ? slotSplitRegex : methodSplitRegex;
   let [forPart, childString] = str.split(splitter);
-  if (isSlot && forPart && !childString) {
+  if (isSlot && !childString && forPart.startsWith("[[")) {
     childString = forPart;
     forPart = "";
   }

--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -91,11 +91,10 @@ function parseInlineIDL(str) {
   // If it's got [[ string ]], then split as an internal slot
   const isSlot = isProbablySlotRegex.test(str);
   const splitter = isSlot ? slotSplitRegex : methodSplitRegex;
-  const [forPart, childString] = str.split(splitter);
+  let [forPart, childString] = str.split(splitter);
   if (isSlot && forPart && !childString) {
-    throw new SyntaxError(
-      `Internal slot missing "for" part. Expected \`{{ InterfaceName/${forPart}}}\` }.`
-    );
+    childString = forPart;
+    forPart = "";
   }
   const tokens = forPart
     .split(/[./]/)

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -689,4 +689,22 @@ describe("Core - Inlines", () => {
     expect(anchor).toBeTruthy();
     expect(anchor.textContent).toBe("[[mySlot]]");
   });
+
+  it("handles {{Foo.[[slot]]}} dot-notation without losing base context", async () => {
+    const body = `
+      <section>
+        <dfn data-dfn-for="MyInterface">[[\\mySlot]]</dfn>
+        <dfn>MyInterface</dfn>
+        <p id="test">{{ MyInterface.[[mySlot]] }}</p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(null, body));
+    const p = doc.getElementById("test");
+    expect(p.textContent).toContain("MyInterface.[[mySlot]]");
+    const anchors = p.querySelectorAll("a");
+    expect(anchors.length).toBe(2);
+    expect(anchors[0].textContent).toBe("MyInterface");
+    expect(anchors[1].textContent).toBe("[[mySlot]]");
+    expect(anchors[1].dataset.linkFor).toBe("MyInterface");
+  });
 });

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -673,4 +673,20 @@ describe("Core - Inlines", () => {
     expect(withSpace.querySelector("a")).toBeNull();
     expect(withSpace.textContent.trim()).toBe("{{ Window }}");
   });
+
+  it("resolves {{[[slot]]}} from ancestor data-link-for", async () => {
+    const body = `
+      <section>
+        <dfn data-dfn-for="MyInterface">[[\\mySlot]]</dfn>
+        <dfn>MyInterface</dfn>
+        <section data-link-for="MyInterface">
+          <p id="test">{{ [[mySlot]] }}</p>
+        </section>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(null, body));
+    const anchor = doc.querySelector("#test a");
+    expect(anchor).toBeTruthy();
+    expect(anchor.textContent).toBe("[[mySlot]]");
+  });
 });

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -651,7 +651,8 @@ describe("Core — xref", () => {
       expect(eventTargetLink.firstElementChild.localName).toBe("code");
 
       const link2 = doc.querySelector("#link2 a");
-      expect(link2).toBeNull();
+      expect(link2).toBeTruthy();
+      expect(link2.classList).toContain("respec-offending-element");
 
       const link3 = doc.querySelector("#link3 a");
       expect(link3.href).toBe("https://dom.spec.whatwg.org/#eventtarget");


### PR DESCRIPTION
Closes #3719

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
