### PR TITLE
fix(core/link-to-dfn): recognize code dfns with empty text nodes

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -256,14 +256,13 @@ function isCode(dfn) {
   if (dfn.closest("code,pre")) {
     return true;
   }
-  // Note that childNodes.length === 1 excludes
-  // definitions that have either other text, or other
-  // whitespace, inside the <dfn>.
-  if (dfn.childNodes.length !== 1) {
+  const children = [...dfn.childNodes].filter(
+    n => !(n.nodeType === Node.TEXT_NODE && (n.textContent ?? "").trim() === "")
+  );
+  if (children.length !== 1) {
     return false;
   }
-  const [first] = /** @type {NodeListOf<HTMLElement>} */ (dfn.childNodes);
-  return first.localName === "code";
+  return /** @type {HTMLElement} */ (children[0]).localName === "code";
 }
 
 /**

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -262,7 +262,9 @@ function isCode(dfn) {
   if (children.length !== 1) {
     return false;
   }
-  return /** @type {HTMLElement} */ (children[0]).localName === "code";
+  const child = children[0];
+  if (child.nodeType !== Node.ELEMENT_NODE) return false;
+  return /** @type {Element} */ (child).localName === "code";
 }
 
 /**

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -388,6 +388,23 @@ describe("Core — Link to definitions", () => {
     expect(codeElem.querySelector("code")).toBeNull();
   });
 
+  it("wraps links in code when dfn>code has surrounding whitespace text nodes", async () => {
+    const bodyText = `
+      <section>
+        <h2>Test Section</h2>
+        <p><dfn>
+          <code>myTerm</code>
+        </dfn></p>
+        <p id="link-target"><a>myTerm</a></p>
+      </section>`;
+    const ops = makeStandardOps(null, bodyText);
+    const doc = await makeRSDoc(ops);
+    const anchor = doc.querySelector("#link-target a");
+    expect(anchor).toBeTruthy();
+    expect(anchor.querySelector("code")).toBeTruthy();
+    expect(anchor.textContent).toBe("myTerm");
+  });
+
   it("does not corrupt data-cite values when shortName is missing", async () => {
     const body = `
       <section>


### PR DESCRIPTION
Closes #3346

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
