### PR TITLE
fix(linter): exclude .introductory from headingless check

### DIFF
--- a/src/core/linter-rules/no-headingless-sections.js
+++ b/src/core/linter-rules/no-headingless-sections.js
@@ -40,7 +40,7 @@ export function run(conf) {
   }
   /** @type {NodeListOf<HTMLElement>} */
   const sections = document.querySelectorAll(
-    "section:not(.head,#abstract,#sotd)"
+    "section:not(.head,.introductory,#abstract,#sotd)"
   );
   const offendingElements = [...sections].filter(
     ({ firstElementChild: e }) =>

--- a/tests/spec/core/linter-rules/no-headingless-sections-spec.js
+++ b/tests/spec/core/linter-rules/no-headingless-sections-spec.js
@@ -81,4 +81,19 @@ describe("Core Linter Rule - 'no-headingless-sections'", () => {
     expect(warnings[0].elements).toHaveSize(1);
     expect(warnings[0].elements[0].id).toBe("badone");
   });
+
+  it("doesn't warn for introductory sections without headings", async () => {
+    const body = `
+      <section class="introductory">
+        <p>Some introductory content without a heading.</p>
+      </section>
+      <section>
+        <h2>Normal section</h2>
+      </section>
+    `;
+    const opts = makeStandardOps(config, body);
+    const doc = await makeRSDoc(opts);
+    const warnings = warningsFilter(doc);
+    expect(warnings).toHaveSize(0);
+  });
 });


### PR DESCRIPTION
Closes #4201

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
