### PR TITLE
fix: revert Iterator helpers to array spread for browser compat

### DIFF
--- a/src/core/highlight-vars.runtime.js
+++ b/src/core/highlight-vars.runtime.js
@@ -54,7 +54,7 @@ function getHighlightColor(target) {
   if (HL_COLORS.get("respec-hl-c1") === true) return "respec-hl-c1";
 
   // otherwise get some other available color
-  return HL_COLORS.keys().find(c => HL_COLORS.get(c)) || "respec-hl-c1";
+  return [...HL_COLORS.keys()].find(c => HL_COLORS.get(c)) || "respec-hl-c1";
 }
 
 /**

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -789,7 +789,7 @@ export class InsensitiveStringSet extends Set {
   getCanonicalKey(key) {
     return super.has(key)
       ? key
-      : this.keys().find(
+      : [...this.keys()].find(
           existingKey => existingKey.toLowerCase() === key.toLowerCase()
         );
   }


### PR DESCRIPTION
Closes #5255

`.keys().find()` on Set/Map iterators requires the ES2025 Iterator Helpers proposal (Chrome 117+, Firefox 131+, Safari 18+). In browsers without support, these throw TypeError, breaking variable highlighting (`highlight-vars.runtime.js`) and case-insensitive reference lookups (`utils.js`).

Reverts to `[...keys()].find()` which works in all browsers ReSpec targets. Introduced in the TypeScript 6 upgrade (#5169).