### PR TITLE
fix(core/xref-db): skip caching empty xref results

### DIFF
--- a/src/core/xref-db.js
+++ b/src/core/xref-db.js
@@ -38,19 +38,13 @@ export async function resolveXrefCache(queries) {
   const requiredKeySet = new Set(queries.map(query => query.id));
   try {
     const cache = await getIdbCache();
-    const tx = cache.transaction(STORE_NAME, "readwrite");
-    let cursor = await tx.store.openCursor();
+    let cursor = await cache.transaction(STORE_NAME).store.openCursor();
     while (cursor) {
       if (requiredKeySet.has(cursor.key)) {
-        if (cursor.value.result?.length) {
-          cachedData.set(cursor.key, cursor.value.result);
-        } else {
-          cursor.delete();
-        }
+        cachedData.set(cursor.key, cursor.value.result);
       }
       cursor = await cursor.continue();
     }
-    await tx.done;
   } catch (err) {
     console.error(err);
   }

--- a/src/core/xref-db.js
+++ b/src/core/xref-db.js
@@ -87,7 +87,8 @@ export async function cacheXrefData(queries, results) {
     const cache = await getIdbCache();
     const tx = cache.transaction(STORE_NAME, "readwrite");
     for (const query of queries) {
-      const result = results.get(query.id) ?? [];
+      const result = results.get(query.id);
+      if (!result?.length) continue;
       tx.objectStore(STORE_NAME).add({ query, result });
     }
     await tx.done;

--- a/src/core/xref-db.js
+++ b/src/core/xref-db.js
@@ -38,13 +38,19 @@ export async function resolveXrefCache(queries) {
   const requiredKeySet = new Set(queries.map(query => query.id));
   try {
     const cache = await getIdbCache();
-    let cursor = await cache.transaction(STORE_NAME).store.openCursor();
+    const tx = cache.transaction(STORE_NAME, "readwrite");
+    let cursor = await tx.store.openCursor();
     while (cursor) {
       if (requiredKeySet.has(cursor.key)) {
-        cachedData.set(cursor.key, cursor.value.result);
+        if (cursor.value.result?.length) {
+          cachedData.set(cursor.key, cursor.value.result);
+        } else {
+          cursor.delete();
+        }
       }
       cursor = await cursor.continue();
     }
+    await tx.done;
   } catch (err) {
     console.error(err);
   }

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -1,13 +1,17 @@
 "use strict";
 
 import {
+  cacheXrefData,
+  clearXrefData,
+  resolveXrefCache,
+} from "../../../src/core/xref-db.js";
+import {
   errorFilters,
   flushIframes,
   makeDefaultBody,
   makeRSDoc,
   makeStandardOps,
 } from "../SpecHelper.js";
-import { clearXrefData } from "../../../src/core/xref-db.js";
 
 describe("Core — xref", () => {
   afterAll(flushIframes);
@@ -1116,5 +1120,70 @@ describe("Core — xref", () => {
     expect(specLink.href).toBe(
       "https://w3c.github.io/reporting/network-reporting.html#endpoint-group"
     );
+  });
+});
+
+describe("Core — xref-db caching", () => {
+  beforeEach(async () => {
+    await clearXrefData();
+    localStorage.setItem("XREF:LAST_VERSION_CHECK", Date.now().toString());
+  });
+
+  afterEach(async () => {
+    await clearXrefData();
+  });
+
+  it("does not cache queries with empty results", async () => {
+    const queries = [
+      { id: "found-term", term: "found", types: ["dfn"] },
+      { id: "missing-term", term: "missing", types: ["dfn"] },
+    ];
+    const results = new Map();
+    results.set("found-term", [{ uri: "#found", shortname: "spec" }]);
+
+    await cacheXrefData(queries, results);
+    const cached = await resolveXrefCache(queries);
+
+    expect(cached.has("found-term")).toBeTrue();
+    expect(cached.has("missing-term")).toBeFalse();
+  });
+
+  it("cleans up pre-existing empty cache entries on read", async () => {
+    const queries = [{ id: "stale-term", term: "stale", types: ["dfn"] }];
+
+    const { promise: dbReady, resolve, reject } = Promise.withResolvers();
+    const req = indexedDB.open("xref", 2);
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+    const db = await dbReady;
+
+    const tx = db.transaction("xrefs", "readwrite");
+    tx.objectStore("xrefs").add({ query: queries[0], result: [] });
+    const { promise: txDone, resolve: txResolve } = Promise.withResolvers();
+    tx.oncomplete = txResolve;
+    await txDone;
+    db.close();
+
+    const cached = await resolveXrefCache(queries);
+    expect(cached.has("stale-term")).toBeFalse();
+
+    const {
+      promise: verifyDbReady,
+      resolve: resolveVerifyDb,
+      reject: rejectVerifyDb,
+    } = Promise.withResolvers();
+    const req2 = indexedDB.open("xref", 2);
+    req2.onsuccess = () => resolveVerifyDb(req2.result);
+    req2.onerror = () => rejectVerifyDb(req2.error);
+    const verifyDb = await verifyDbReady;
+
+    const verifyTx = verifyDb.transaction("xrefs", "readonly");
+    const getReq = verifyTx.objectStore("xrefs").get("stale-term");
+    const { promise: getReady, resolve: resolveGet } = Promise.withResolvers();
+    getReq.onsuccess = () => resolveGet(getReq.result);
+    const remaining = await getReady;
+    verifyDb.close();
+
+    expect(remaining).toBeUndefined();
   });
 });

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -1147,43 +1147,4 @@ describe("Core — xref-db caching", () => {
     expect(cached.has("found-term")).toBeTrue();
     expect(cached.has("missing-term")).toBeFalse();
   });
-
-  it("cleans up pre-existing empty cache entries on read", async () => {
-    const queries = [{ id: "stale-term", term: "stale", types: ["dfn"] }];
-
-    const { promise: dbReady, resolve, reject } = Promise.withResolvers();
-    const req = indexedDB.open("xref", 2);
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-    const db = await dbReady;
-
-    const tx = db.transaction("xrefs", "readwrite");
-    tx.objectStore("xrefs").add({ query: queries[0], result: [] });
-    const { promise: txDone, resolve: txResolve } = Promise.withResolvers();
-    tx.oncomplete = txResolve;
-    await txDone;
-    db.close();
-
-    const cached = await resolveXrefCache(queries);
-    expect(cached.has("stale-term")).toBeFalse();
-
-    const {
-      promise: verifyDbReady,
-      resolve: resolveVerifyDb,
-      reject: rejectVerifyDb,
-    } = Promise.withResolvers();
-    const req2 = indexedDB.open("xref", 2);
-    req2.onsuccess = () => resolveVerifyDb(req2.result);
-    req2.onerror = () => rejectVerifyDb(req2.error);
-    const verifyDb = await verifyDbReady;
-
-    const verifyTx = verifyDb.transaction("xrefs", "readonly");
-    const getReq = verifyTx.objectStore("xrefs").get("stale-term");
-    const { promise: getReady, resolve: resolveGet } = Promise.withResolvers();
-    getReq.onsuccess = () => resolveGet(getReq.result);
-    const remaining = await getReady;
-    verifyDb.close();
-
-    expect(remaining).toBeUndefined();
-  });
 });


### PR DESCRIPTION
Closes #5256

When the xref API returns no result for a query, \`cacheXrefData()\` stored an empty array in IDB. On subsequent loads, the cache hit prevented re-fetching, permanently suppressing results for terms that were temporarily missing from the API.

Skips caching queries with no results so they are re-fetched next time.