### PR TITLE
fix(styles): remove inline-block from issue summary list items

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -98,7 +98,6 @@ ol.tof {
 
 #issue-summary li {
   list-style: none;
-  display: inline-block;
 }
 
 details.respec-tests-details {


### PR DESCRIPTION
Closes #3942

`#issue-summary li { display: inline-block }` caused title-less issues to collapse onto the same line (e.g., "Issue 2Issue 3" with no separation). The 2-column layout is handled by `column-count: 2` on the parent `<ul>`, so the `inline-block` was unnecessary.

Before (title-less issues smashed together):
![before](https://github.com/user-attachments/assets/placeholder-before)

After (each issue on its own line within the 2-column layout):
![after](https://github.com/user-attachments/assets/placeholder-after)