### PR TITLE
fix(w3c/headers): derive /TR pubSpace for multi-group specs

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -684,7 +684,11 @@ function derivePubSpace(conf) {
   if (conf.isNoTrack && !conf.isCGBG && !conf.isTagFinding) {
     return "";
   }
-  if (trStatus.includes(specStatus ?? "") || conf.groupType === "wg") {
+  const groupType = conf.groupType;
+  const isWG =
+    groupType === "wg" ||
+    (Array.isArray(groupType) && groupType.includes("wg"));
+  if (trStatus.includes(specStatus ?? "") || isWG) {
     return `/TR`;
   }
 

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1469,6 +1469,27 @@ describe("W3C — Headers", () => {
       expect(latestVersionEl.textContent.trim()).toBe("none");
     });
 
+    it("derives /TR latestVersion for multi-group ED specs", async () => {
+      const ops = makeStandardOps({
+        shortName: "multi-group-test",
+        specStatus: "ED",
+        group: ["das", "webapps"],
+        edDraftURI: "https://example.com/ed/",
+      });
+      const doc = await makeRSDoc(ops);
+
+      const terms = [...doc.querySelectorAll("dt")];
+      const latestVersion = terms.find(
+        el => el.textContent.trim() === "Latest published version:"
+      );
+      expect(latestVersion).toBeTruthy();
+      const latestVersionLink =
+        latestVersion.nextElementSibling.querySelector("a");
+      expect(latestVersionLink.href).toBe(
+        "https://www.w3.org/TR/multi-group-test/"
+      );
+    });
+
     it("allows overriding latest published version to a different location", async () => {
       const ops = makeStandardOps({
         shortName: "spec",


### PR DESCRIPTION
Closes #4688

When `group` is an array (e.g., `["das", "webapps"]`), `conf.groupType` becomes an array like `["wg", "wg"]`. The strict equality check `conf.groupType === "wg"` always fails for arrays, so `derivePubSpace` returned `undefined`, producing an incorrect or empty `latestVersion`.

Now checks both string and array forms of `groupType`.

Visually verified in Safari with `group: ["das", "webapps"], specStatus: "ED", shortName: "geolocation"`: "Latest published version" correctly shows `https://www.w3.org/TR/geolocation/`.