### PR TITLE
fix: unify noToc/noTOC config to canonical noTOC

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/setup-node@v6
         with: { node-version-file: '.nvmrc', cache: pnpm }
       - run: pnpm i --frozen-lockfile
-      - run: pnpm build:w3c & pnpm build:geonovum
+      - run: pnpm build:w3c & pnpm build:geonovum & pnpm build:aom & pnpm build:dini
       - run: pnpm test:unit
         env:
           BROWSERS: ${{ matrix.browser }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-node@v6
         with: { node-version-file: '.nvmrc', cache: pnpm }
       - run: pnpm i --frozen-lockfile
-      - run: pnpm build:w3c & pnpm build:geonovum
+      - run: pnpm build:w3c & pnpm build:geonovum & pnpm build:aom & pnpm build:dini
       - run: pnpm test
         env:
           BROWSERS: ChromeHeadless

--- a/src/aom/defaults.js
+++ b/src/aom/defaults.js
@@ -64,7 +64,7 @@ export function run(conf) {
     lint,
   });
 
-  if ("noToc" in conf) conf.noTOC = conf.noToc;
+  if ("noToc" in conf && !("noTOC" in conf)) conf.noTOC = conf.noToc;
   // computed properties
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/aom/defaults.js
+++ b/src/aom/defaults.js
@@ -64,6 +64,7 @@ export function run(conf) {
     lint,
   });
 
+  if ("noToc" in conf) conf.noTOC = conf.noToc;
   // computed properties
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/aom/style.js
+++ b/src/aom/style.js
@@ -132,7 +132,7 @@ export function run(conf) {
   }
 
   // Attach W3C fixup script after we are done.
-  if (!conf.noToc) {
+  if (!conf.noTOC) {
     sub(
       "end-all",
       () => {

--- a/src/dini/defaults.js
+++ b/src/dini/defaults.js
@@ -78,6 +78,7 @@ export function run(conf) {
     lint,
   });
 
+  if ("noToc" in conf) conf.noTOC = conf.noToc;
   // computed properties
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/dini/defaults.js
+++ b/src/dini/defaults.js
@@ -78,7 +78,7 @@ export function run(conf) {
     lint,
   });
 
-  if ("noToc" in conf) conf.noTOC = conf.noToc;
+  if ("noToc" in conf && !("noTOC" in conf)) conf.noTOC = conf.noToc;
   // computed properties
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/dini/style.js
+++ b/src/dini/style.js
@@ -132,7 +132,7 @@ export function run(conf) {
   }
 
   // Attach W3C fixup script after we are done.
-  if (!conf.noToc) {
+  if (!conf.noTOC) {
     sub(
       "end-all",
       () => {

--- a/src/geonovum/defaults.js
+++ b/src/geonovum/defaults.js
@@ -84,6 +84,6 @@ export function run(conf) {
   });
   // computed properties
 
-  if ("noToc" in conf) conf.noTOC = conf.noToc;
+  if ("noToc" in conf && !("noTOC" in conf)) conf.noTOC = conf.noToc;
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/geonovum/defaults.js
+++ b/src/geonovum/defaults.js
@@ -83,5 +83,7 @@ export function run(conf) {
     lint,
   });
   // computed properties
+
+  if ("noToc" in conf) conf.noTOC = conf.noToc;
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/geonovum/style.js
+++ b/src/geonovum/style.js
@@ -152,7 +152,7 @@ export function run(conf) {
       styleFile = "base.css";
   }
 
-  if (!conf.noToc) {
+  if (!conf.noTOC) {
     sub(
       "end-all",
       () => {

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -97,9 +97,13 @@ interface StoredBiblioEntry extends BiblioData {
  * `true`, `false`, or `"warn"` / `"error"`.
  * Supports string indexing so linter-rule files can look up individual rules.
  */
-type LintConfig = false | ({ [ruleName: string]: boolean | string });
+type LintConfig = false | { [ruleName: string]: boolean | string };
 
-type ProcessFn = (config: Conf, doc: Document, utils?: unknown) => Promise<void> | void;
+type ProcessFn = (
+  config: Conf,
+  doc: Document,
+  utils?: unknown
+) => Promise<void> | void;
 
 /** Configuration object type */
 interface Conf {
@@ -119,6 +123,7 @@ interface Conf {
   afterEnd?: ProcessFn;
   specStatus?: string;
   wgId?: string;
+  /** @deprecated Use noTOC instead */
   noToc?: boolean;
   noTOC?: boolean;
   /** Disables injecting ReSpec styles */
@@ -131,24 +136,26 @@ interface Conf {
   /** The URL of the pull request, if applicable */
   prUrl?: string;
   /** The GitHub configuration object */
-  github?: string | {
-    /** The URL of the GitHub repository */
-    repoURL: string;
-    /** The default branch name */
-    branch?: string;
-    /** Optional custom pulls URL (for monorepo scenarios) */
-    pullsURL?: string;
-    /** Optional custom commit history URL (for monorepo scenarios) */
-    commitHistoryURL?: string;
-    /** The API base URL */
-    apiBase?: string;
-    /** The full name of the repo (e.g. "w3c/my-spec") */
-    fullName?: string;
-    /** The issues URL */
-    issuesURL?: string;
-    /** The new issues URL */
-    newIssuesURL?: string;
-  };
+  github?:
+    | string
+    | {
+        /** The URL of the GitHub repository */
+        repoURL: string;
+        /** The default branch name */
+        branch?: string;
+        /** Optional custom pulls URL (for monorepo scenarios) */
+        pullsURL?: string;
+        /** Optional custom commit history URL (for monorepo scenarios) */
+        commitHistoryURL?: string;
+        /** The API base URL */
+        apiBase?: string;
+        /** The full name of the repo (e.g. "w3c/my-spec") */
+        fullName?: string;
+        /** The issues URL */
+        issuesURL?: string;
+        /** The new issues URL */
+        newIssuesURL?: string;
+      };
   /** The title of the document */
   title?: string;
 
@@ -349,15 +356,21 @@ interface Conf {
   /** Linting configuration */
   lint?: LintConfig;
   /** caniuse.com feature configuration */
-  caniuse?: string | {
-    feature?: string;
-    browsers?: string[] | Record<string, string[]>;
-    maxAge?: number;
-    removeOnSave?: boolean;
-    [key: string]: unknown;
-  };
+  caniuse?:
+    | string
+    | {
+        feature?: string;
+        browsers?: string[] | Record<string, string[]>;
+        maxAge?: number;
+        removeOnSave?: boolean;
+        [key: string]: unknown;
+      };
   /** External cross-reference configuration */
-  xref?: boolean | string | string[] | { url?: string; specs?: string[]; profile?: string };
+  xref?:
+    | boolean
+    | string
+    | string[]
+    | { url?: string; specs?: string[]; profile?: string };
   /** Whether to include JSON-LD metadata */
   doJsonLd?: boolean;
   /** Whether to highlight variables */
@@ -373,9 +386,20 @@ interface Conf {
   /** Accessibility linting configuration */
   a11y?: boolean | Record<string, unknown>;
   /** MDN annotation configuration */
-  mdn?: boolean | string | { key?: string; specMapUrl?: string; baseJsonPath?: string; maxAge?: number };
+  mdn?:
+    | boolean
+    | string
+    | {
+        key?: string;
+        specMapUrl?: string;
+        baseJsonPath?: string;
+        maxAge?: number;
+      };
   /** Web Monetization configuration */
-  monetization?: boolean | string | { paymentPointer?: string; removeOnSave?: boolean };
+  monetization?:
+    | boolean
+    | string
+    | { paymentPointer?: string; removeOnSave?: boolean };
   /** RFC 2119 usage tracking object, keyed by term */
   respecRFC2119?: Record<string, boolean>;
   /** Whether to place the SotD additional content after the WG info */

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -75,7 +75,7 @@ export function run(conf) {
     lint,
   });
 
-  if ("noToc" in conf) conf.noTOC = conf.noToc;
+  if ("noToc" in conf && !("noTOC" in conf)) conf.noTOC = conf.noToc;
   if (conf.specStatus !== "unofficial" && !conf.hasOwnProperty("license")) {
     conf.license = "w3c-software-doc";
   }

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -75,6 +75,7 @@ export function run(conf) {
     lint,
   });
 
+  if ("noToc" in conf) conf.noTOC = conf.noToc;
   if (conf.specStatus !== "unofficial" && !conf.hasOwnProperty("license")) {
     conf.license = "w3c-software-doc";
   }

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -105,7 +105,7 @@ function styleMover(linkURL) {
  */
 export function run(conf) {
   // Attach W3C fixup script after we are done.
-  if (!conf.noToc) {
+  if (!conf.noTOC) {
     sub("end-all", attachFixupScript, { once: true });
   }
 

--- a/tests/spec/aom/style-spec.js
+++ b/tests/spec/aom/style-spec.js
@@ -59,4 +59,12 @@ describe("AOM - Style", () => {
     const elem = doc.querySelector(query);
     expect(elem).toBeNull();
   });
+
+  it("doesn't include fixup.js when legacy noToc is set", async () => {
+    const ops = makeStandardAomOps({ noToc: true });
+    const doc = await makeRSDoc(ops);
+    const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
+    const elem = doc.querySelector(query);
+    expect(elem).toBeNull();
+  });
 });

--- a/tests/spec/aom/style-spec.js
+++ b/tests/spec/aom/style-spec.js
@@ -52,8 +52,8 @@ describe("AOM - Style", () => {
     expect(elem.content).toBe(expectedStr);
   });
 
-  it("doesn't include fixup.js when noToc is set", async () => {
-    const ops = makeStandardAomOps({ noToc: true });
+  it("doesn't include fixup.js when noTOC is set", async () => {
+    const ops = makeStandardAomOps({ noTOC: true });
     const doc = await makeRSDoc(ops);
     const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
     const elem = doc.querySelector(query);

--- a/tests/spec/core/id-headers-spec.js
+++ b/tests/spec/core/id-headers-spec.js
@@ -58,7 +58,7 @@ describe("Core - ID headers", () => {
       ariaLabel = deepAppendix.getAttribute("aria-label");
       expect(ariaLabel).toBe("Permalink for Appendix A.1");
 
-      // marked as noToc
+      // marked as noTOC
       const deepH4 = doc.querySelector("h4 + a.self-link");
       ariaLabel = deepH4.getAttribute("aria-label");
       expect(ariaLabel).toBe("Permalink for this Section");

--- a/tests/spec/geonovum/style-spec.js
+++ b/tests/spec/geonovum/style-spec.js
@@ -98,4 +98,13 @@ describe("Geonovum - Style", () => {
     const elem = doc.querySelector(query);
     expect(elem).toBeNull();
   });
+
+  it("shouldn't include fixup.js when legacy noToc is set", async () => {
+    const ops = makeStandardGeoOps();
+    Object.assign(ops.config, { noToc: true });
+    const doc = await makeRSDoc(ops);
+    const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
+    const elem = doc.querySelector(query);
+    expect(elem).toBeNull();
+  });
 });

--- a/tests/spec/geonovum/style-spec.js
+++ b/tests/spec/geonovum/style-spec.js
@@ -87,10 +87,10 @@ describe("Geonovum - Style", () => {
     );
   });
 
-  it("shouldn't include fixup.js when noToc is set", async () => {
+  it("shouldn't include fixup.js when noTOC is set", async () => {
     const ops = makeStandardGeoOps();
     const newProps = {
-      noToc: true,
+      noTOC: true,
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -262,6 +262,15 @@ describe("W3C - Style", () => {
     expect(elem).toBeNull();
   });
 
+  it("shouldn't include fixup.js when legacy noToc is set", async () => {
+    const ops = makeStandardOps();
+    Object.assign(ops.config, { noToc: true });
+    const doc = await makeRSDoc(ops, "spec/core/simple.html");
+    const query = "script[src^='https://www.w3.org/scripts/TR/2021/fixup.js']";
+    const elem = doc.querySelector(query);
+    expect(elem).toBeNull();
+  });
+
   it("does not append empty text nodes to head when moving stylesheets on export", async () => {
     const ops = makeStandardOps({});
     const doc = await getExportedDoc(await makeRSDoc(ops));

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -256,7 +256,7 @@ describe("W3C - Style", () => {
       noTOC: true,
     };
     Object.assign(ops.config, newProps);
-    const doc = await makeRSDoc(ops, "spec/core/simple.html");
+    const doc = await makeRSDoc(ops);
     const query = "script[src^='https://www.w3.org/scripts/TR/2021/fixup.js']";
     const elem = doc.querySelector(query);
     expect(elem).toBeNull();
@@ -265,7 +265,7 @@ describe("W3C - Style", () => {
   it("shouldn't include fixup.js when legacy noToc is set", async () => {
     const ops = makeStandardOps();
     Object.assign(ops.config, { noToc: true });
-    const doc = await makeRSDoc(ops, "spec/core/simple.html");
+    const doc = await makeRSDoc(ops);
     const query = "script[src^='https://www.w3.org/scripts/TR/2021/fixup.js']";
     const elem = doc.querySelector(query);
     expect(elem).toBeNull();

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -250,10 +250,10 @@ describe("W3C - Style", () => {
     expect(linkBase.nextElementSibling).toBe(linkDarkMode);
   });
 
-  it("shouldn't include fixup.js when noToc is set", async () => {
+  it("shouldn't include fixup.js when noTOC is set", async () => {
     const ops = makeStandardOps();
     const newProps = {
-      noToc: true,
+      noTOC: true,
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops, "spec/core/simple.html");


### PR DESCRIPTION
Closes #5258

The config property was split: style movers used `noToc` (lowercase c) while `structure.js` used `noTOC` (uppercase C). A spec author setting one would not affect the other.

Canonical name is `noTOC` (matching the documentation and the acronym convention used by `edDraftURI`). The old `noToc` is normalized to `noTOC` in each profile's defaults module for backwards compatibility.

Verified in Safari: `noToc: true` correctly suppresses both the TOC and the fixup script.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
