### PR TITLE
fix(styles): add width:100% to .header-wrapper for flexbox layout

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -148,6 +148,7 @@ aside.example .marker > a.self-link {
 .header-wrapper {
   display: flex;
   align-items: baseline;
+  width: 100%;
 }
 
 :is(h2, h3, h4, h5, h6):not(#toc > h2, #abstract > h2, #sotd > h2, .head > h2):has(+ a.self-link) {


### PR DESCRIPTION
Closes #5150

Without an explicit width, flex containers with small content can wrap alongside adjacent elements instead of taking a full row.