### PR TITLE
fix(core/structure): propagate custom heading ID to section element

### DIFF
--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -164,7 +164,12 @@ function getSectionTree(parent) {
       continue;
     }
     const title = header.textContent;
-    addId(section, undefined, title);
+    if (header.id && !section.id) {
+      section.id = header.id;
+      header.removeAttribute("id");
+    } else {
+      addId(section, undefined, title);
+    }
     sections.push({
       element: section,
       header,


### PR DESCRIPTION
Closes #4947

When a heading has a custom ID (from {#custom-id} markdown syntax), moves it to the wrapping section element instead of generating a separate auto-ID from the heading text. Ensures section and heading share one canonical ID for fragment navigation and tools like webref that expect section-level IDs.