### PR TITLE
fix(styles): add width:100% to .header-wrapper for flexbox layout

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -148,6 +148,7 @@ aside.example .marker > a.self-link {
 .header-wrapper {
   display: flex;
   align-items: baseline;
+  width: 100%;
 }
 
 :is(h2, h3, h4, h5, h6):not(#toc > h2, #abstract > h2, #sotd > h2, .head > h2):has(+ a.self-link) {


### PR DESCRIPTION
Closes #5150

Add width:100% to .header-wrapper so the flex container spans full
width when nested inside another flex or grid context.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
