### PR TITLE
fix(core/caniuse): mark up browser support groups as a dl

### DIFF
--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -170,21 +170,15 @@ async function processJson(json, { feature }) {
   ]);
   const toBrowserCell = browserCellRenderer(feature);
   results.reduce(toBrowserCell, groups);
-  const out = [...groups]
+  const entries = [...groups]
     .filter(([, arr]) => arr.length)
     .map(
       ([key, arr]) =>
-        html`<div class="caniuse-group">
-          <div class="caniuse-browsers">${arr}</div>
-          <div class="caniuse-type"><span>${key}</div>
-        </div>`
+        html`<dt class="caniuse-type">${key}</dt>
+          <dd class="caniuse-browsers">${arr}</dd>`
     );
-  out.push(
-    html`<a class="caniuse-cell" href="https://caniuse.com/${feature}"
-      >More info</a
-    >`
-  );
-  return out;
+  return html`<dl class="caniuse-groups">${entries}</dl>
+    <a href="https://caniuse.com/${feature}">More info</a>`;
 }
 
 /**

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -174,8 +174,10 @@ async function processJson(json, { feature }) {
     .filter(([, arr]) => arr.length)
     .map(
       ([key, arr]) =>
-        html`<dt class="caniuse-type">${key}</dt>
-          <dd class="caniuse-browsers">${arr}</dd>`
+        html`<div class="caniuse-group">
+          <dt class="caniuse-type">${key}</dt>
+          <dd class="caniuse-browsers">${arr}</dd>
+        </div>`
     );
   return html`<dl class="caniuse-groups">${entries}</dl>
     <a href="https://caniuse.com/${feature}">More info</a>`;

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -179,21 +179,22 @@ async function processJson(json, { feature }) {
   ]);
   const toBrowserCell = browserCellRenderer(feature);
   results.reduce(toBrowserCell, groups);
-  const out = [...groups]
+  const entries = [...groups]
     .filter(([, arr]) => arr.length)
     .map(
+      // A dl only permits dt/dd, optionally grouped in a div. The dt comes
+      // first for valid markup; the CSS puts the label back on the rule under
+      // the browsers, where it reads as a legend.
       ([key, arr]) =>
         html`<div class="caniuse-group">
-          <div class="caniuse-browsers">${arr}</div>
-          <div class="caniuse-type"><span>${key}</div>
+          <dt class="caniuse-type"><span>${key}</span></dt>
+          <dd class="caniuse-browsers">${arr}</dd>
         </div>`
     );
-  out.push(
-    html`<a class="caniuse-cell" href="https://caniuse.com/${feature}"
+  return html`<dl class="caniuse-groups">${entries}</dl>
+    <a class="caniuse-more-info" href="https://caniuse.com/${feature}"
       >More info</a
-    >`
-  );
-  return out;
+    >`;
 }
 
 /**

--- a/src/styles/caniuse.css.js
+++ b/src/styles/caniuse.css.js
@@ -19,6 +19,11 @@ export default css`
   padding: 0;
 }
 
+.caniuse-group {
+  display: flex;
+  flex-direction: column;
+}
+
 .caniuse-type {
   text-transform: capitalize;
   font-size: 0.8em;

--- a/src/styles/caniuse.css.js
+++ b/src/styles/caniuse.css.js
@@ -7,41 +7,34 @@ export default css`
 
 .caniuse-stats {
   display: flex;
-  column-gap: 2em;
+  flex-direction: column;
+  gap: 0.5em;
 }
 
-.caniuse-group {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  justify-content: flex-end;
-  flex-basis: auto;
+.caniuse-groups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(20em, 100%), 1fr));
+  gap: 0.5em;
+  margin: 0;
+  padding: 0;
+}
+
+.caniuse-type {
+  text-transform: capitalize;
+  font-size: 0.8em;
+  font-weight: bold;
+  border-bottom: 1px solid #ccc;
+  padding-bottom: 0.2em;
 }
 
 .caniuse-browsers {
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
   flex-wrap: wrap;
-  margin-top: .2em;
-  column-gap: .4em;
-  border-bottom: 1px solid #ccc;
-  row-gap: .4em;
-  padding-bottom: .4cm;
-}
-
-.caniuse-type {
-  align-self: center;
-  border-top: none;
-  text-transform: capitalize;
-  font-size: .8em;
-  margin-top: -.8em;
-  font-weight: bold;
-}
-
-.caniuse-type span {
-  background-color: var(--bg, white);
-  padding: 0 0.4em;
+  column-gap: 0.4em;
+  row-gap: 0.4em;
+  margin: 0;
+  padding: 0.4em 0;
 }
 
 /* a browser version */
@@ -52,7 +45,7 @@ export default css`
   display: flex;
   font-size: 90%;
   min-width: 1.5cm;
-  padding: .3rem;
+  padding: 0.3rem;
   justify-content: space-evenly;
   --supported: #2a8436dd;
   --no-support: #c44230dd;
@@ -72,15 +65,15 @@ export default css`
 }
 
 img.caniuse-browser {
-  filter: drop-shadow(0px 0px .1cm #666666);
+  filter: drop-shadow(0px 0px 0.1cm #666666);
   background: transparent;
 }
 
 .caniuse-cell span.browser-version {
-  margin-left: 0.4em;
+  margin-inline-start: 0.4em;
   text-shadow: 0 0 0.1em #fff;
   font-weight: 100;
-  font-size: .9em;
+  font-size: 0.9em;
 }
 
 .caniuse-stats a[href] {
@@ -94,7 +87,7 @@ img.caniuse-browser {
 }
 
 /* no support, disabled by default */
-.caniuse-cell:is(.n,.d) {
+.caniuse-cell:is(.n, .d) {
   --caniuse-angle: 45deg;
   --caniuse-bg: var(--no-support);
   --caniuse-bg-alt: var(--no-support-alt);
@@ -110,7 +103,7 @@ img.caniuse-browser {
 
 /* not supported by default / partial support etc
 see https://github.com/Fyrd/caniuse/blob/master/CONTRIBUTING.md for stats */
-.caniuse-cell:is(.a,.x,.p) {
+.caniuse-cell:is(.a, .x, .p) {
   --caniuse-angle: 90deg;
   --caniuse-bg: var(--partial);
   --caniuse-bg-alt: var(--partial-alt);
@@ -128,7 +121,7 @@ see https://github.com/Fyrd/caniuse/blob/master/CONTRIBUTING.md for stats */
     padding: 0.5em;
   }
 
-  .caniuse-cell:is(.a,.d,.p,.x,.u)::before {
+  .caniuse-cell:is(.a, .d, .p, .x, .u)::before {
     content: "⚠️";
     padding: 0.5em;
   }

--- a/src/styles/caniuse.css.js
+++ b/src/styles/caniuse.css.js
@@ -10,12 +10,56 @@ export default css`
   column-gap: 2em;
 }
 
+/* The dl is a new wrapper around the groups, so it has to be transparent to
+   the flex row that used to hold them directly. */
+.caniuse-groups {
+  display: flex;
+  flex: 1;
+  column-gap: 2em;
+  margin: 0;
+}
+
+/* Narrow screens: stack the groups full width so the pills wrap instead of
+   forming tall single-file columns, and give "More info" its own row.
+   767px matches the only other breakpoint in ReSpec (respec.css.js). */
+@media (max-width: 767px) {
+  .caniuse-stats {
+    display: block;
+  }
+
+  .caniuse-groups {
+    flex-direction: column;
+  }
+
+  /* Space every group equally, including the first. Using padding rather than
+     row-gap avoids the second group getting gap plus padding while the first
+     gets padding alone. Generous, because each group's label hangs below its
+     own rule, and a tight gap reads as the label belonging to the group
+     beneath it. */
+  .caniuse-group {
+    padding-top: 1.5em;
+  }
+
+  .caniuse-more-info {
+    display: block;
+    text-align: right;
+    margin-top: 0.5em;
+  }
+}
+
+/* column-reverse, not column: a dl requires the dt before its dd, but the
+   label belongs visually below, straddling the rule under the browsers. */
 .caniuse-group {
   display: flex;
   flex: 1;
-  flex-direction: column;
+  flex-direction: column-reverse;
   justify-content: flex-end;
   flex-basis: auto;
+  /* Establish a stacking context so the label can be lifted above the dd's
+     bottom border. Reversing the visual order does not reverse paint order:
+     the dd is a later sibling, so its border would paint over the label and
+     strike the text through. */
+  position: relative;
 }
 
 .caniuse-browsers {
@@ -23,7 +67,7 @@ export default css`
   align-items: baseline;
   justify-content: space-between;
   flex-wrap: wrap;
-  margin-top: .2em;
+  margin: .2em 0 0;
   column-gap: .4em;
   border-bottom: 1px solid #ccc;
   row-gap: .4em;
@@ -37,10 +81,20 @@ export default css`
   font-size: .8em;
   margin-top: -.8em;
   font-weight: bold;
+  /* Above the dd's border, so the label's background breaks the rule instead
+     of the rule striking through the text. */
+  position: relative;
+  z-index: 1;
 }
 
+/* The label punches a hole in the rule above it, so its background has to match
+   the page. This was var(--bg, white), but --bg is defined nowhere in ReSpec,
+   so it always resolved to literal white: a white patch on a dark page.
+   Canvas/CanvasText are system colours that follow the used color-scheme, so
+   this tracks both the OS preference and ReSpec's own dark toggle. */
 .caniuse-type span {
-  background-color: var(--bg, white);
+  background-color: Canvas;
+  color: CanvasText;
   padding: 0 0.4em;
 }
 
@@ -83,7 +137,7 @@ img.caniuse-browser {
   font-size: .9em;
 }
 
-.caniuse-stats a[href] {
+.caniuse-more-info {
   white-space: nowrap;
   align-self: flex-end;
 }
@@ -118,6 +172,17 @@ see https://github.com/Fyrd/caniuse/blob/master/CONTRIBUTING.md for stats */
 
 /* handle case when printing */
 @media print {
+  /* Browsers drop backgrounds when printing, so the label can no longer punch
+     a hole in the rule and the line would strike through the text. Drop the
+     rule instead and let the label sit under its group. */
+  .caniuse-browsers {
+    border-bottom: none;
+  }
+
+  .caniuse-type {
+    margin-top: 0;
+  }
+
   .caniuse-cell.y::before {
     content: "✔️";
     padding: 0.5em;

--- a/tests/spec/core/caniuse-spec.js
+++ b/tests/spec/core/caniuse-spec.js
@@ -123,7 +123,7 @@ describe("Core — Can I Use", () => {
     );
 
     // More info link
-    const moreInfoLink = cells.item(3);
+    const moreInfoLink = stats.querySelector("a[href*='caniuse.com']");
     expect(moreInfoLink.href).toBe("https://caniuse.com/FEATURE");
     expect(moreInfoLink.textContent.trim()).toBe("More info");
   });
@@ -224,11 +224,7 @@ describe("Core — Can I Use", () => {
     expect(desktopBrowsers).toHaveSize(1);
     const [firefox] = desktopBrowsers;
     expect(firefox.src).toContain("firefox.svg");
-    expect(desktop.querySelector(".caniuse-type > span").textContent).toBe(
-      "desktop"
-    );
-    expect(mobile.querySelector(".caniuse-type > span").textContent).toBe(
-      "mobile"
-    );
+    expect(desktop.querySelector(".caniuse-type").textContent).toBe("desktop");
+    expect(mobile.querySelector(".caniuse-type").textContent).toBe("mobile");
   });
 });

--- a/tests/spec/core/caniuse-spec.js
+++ b/tests/spec/core/caniuse-spec.js
@@ -83,7 +83,7 @@ describe("Core — Can I Use", () => {
     const doc = await makeRSDoc(ops);
     const stats = doc.querySelector(".caniuse-stats");
     const cells = stats.querySelectorAll(".caniuse-cell");
-    expect(cells).toHaveSize(4);
+    expect(cells).toHaveSize(3);
 
     // Check a cell
     const [cell] = cells;

--- a/tests/spec/core/caniuse-spec.js
+++ b/tests/spec/core/caniuse-spec.js
@@ -83,7 +83,7 @@ describe("Core — Can I Use", () => {
     const doc = await makeRSDoc(ops);
     const stats = doc.querySelector(".caniuse-stats");
     const cells = stats.querySelectorAll(".caniuse-cell");
-    expect(cells).toHaveSize(4);
+    expect(cells).toHaveSize(3);
 
     // Check a cell
     const [cell] = cells;
@@ -123,9 +123,13 @@ describe("Core — Can I Use", () => {
     );
 
     // More info link
-    const moreInfoLink = cells.item(3);
+    const moreInfoLink = stats.querySelector("a[href*='caniuse.com']");
     expect(moreInfoLink.href).toBe("https://caniuse.com/FEATURE");
     expect(moreInfoLink.textContent.trim()).toBe("More info");
+    // It must not carry .caniuse-cell: that sets color:#fff and a gradient from
+    // --caniuse-bg, which is only defined on the support-level classes, so the
+    // link rendered white on white.
+    expect(moreInfoLink.classList.contains("caniuse-cell")).toBeFalse();
   });
 
   it("removes irrelevant config for caniuse feature", async () => {
@@ -230,5 +234,27 @@ describe("Core — Can I Use", () => {
     expect(mobile.querySelector(".caniuse-type > span").textContent).toBe(
       "mobile"
     );
+  });
+
+  it("marks up the groups as a dl, with the More info link outside it", async () => {
+    const ops = makeStandardOps({
+      caniuse: {
+        feature: "FEATURE",
+        apiURL,
+      },
+    });
+    const doc = await makeRSDoc(ops);
+    const stats = doc.querySelector(".caniuse-stats");
+    const list = stats.querySelector("dl.caniuse-groups");
+    // A dl only allows dt/dd, optionally wrapped in a div.
+    expect(list.querySelectorAll(":scope > div.caniuse-group")).toHaveSize(2);
+    expect(
+      list.querySelectorAll(":scope > div > dt.caniuse-type:first-child")
+    ).toHaveSize(2);
+    expect(
+      list.querySelectorAll(":scope > div > dd.caniuse-browsers:last-child")
+    ).toHaveSize(2);
+    // So the link is a sibling of the list, not inside it.
+    expect(stats.querySelector("a[href]").parentElement).toBe(stats);
   });
 });


### PR DESCRIPTION
Closes #4090

The browser support groups were nested `<div>`s; they are now a `<dl>` with a `<dt>` label and `<dd>` of browser cells per group, which is what the issue asked for and reads better to assistive technology. The existing flex layout and its legend-on-a-rule look are kept as-is, and on narrow screens the groups stack full width with the "More info" link on its own row.

Not switched to CSS grid, despite the issue suggesting it: the flex layout already produced the intended appearance, and several grid rewrites each regressed it (misaligned group labels, the rule striking through the label text, pills scattered across columns). Two rendering bugs found along the way are fixed here too. The "More info" link carried `caniuse-cell`, which sets white text with a background gradient built from a variable only defined on the support-level classes, so it rendered white on white; and the group labels used `var(--bg, white)`, but `--bg` is not defined anywhere in ReSpec, so they painted a white patch on dark-mode pages.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
