### PR TITLE
fix(styles/webidl): add dark mode color variants for contrast

### DIFF
--- a/src/styles/webidl.css.js
+++ b/src/styles/webidl.css.js
@@ -136,4 +136,39 @@ a.idlEnumItem {
     visibility: hidden;
   }
 }
+
+@media (prefers-color-scheme: dark) {
+  .idlHeader {
+    background: #1a5276;
+    color: #e8e8e8;
+  }
+
+  .idlID,
+  .idlType,
+  .idlSuperclass {
+    color: #6cb4ee;
+  }
+
+  .idlName {
+    color: #ff7b4f;
+  }
+
+  .idlName a {
+    color: #ff7b4f;
+    border-bottom-color: #ff7b4f;
+  }
+
+  a.idlEnumItem {
+    color: #e8e8e8;
+    border-bottom-color: #555;
+  }
+
+  .extAttr {
+    color: #aaa;
+  }
+
+  .idlSectionComment {
+    color: #999;
+  }
+}
 `;


### PR DESCRIPTION
Partially addresses #4871

Add prefers-color-scheme: dark overrides for WebIDL syntax colors
that have poor contrast on dark backgrounds.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
