### PR TITLE
fix(core/markdown): skip entity unescaping for data-include content

### DIFF
--- a/src/core/data-include.js
+++ b/src/core/data-include.js
@@ -25,7 +25,7 @@ function fillWithText(el, data, { replace }) {
   const { includeFormat } = el.dataset;
   let fill = data;
   if (includeFormat === "markdown") {
-    fill = markdownToHtml(fill);
+    fill = markdownToHtml(fill, { fromHTML: false });
   }
 
   if (includeFormat === "text") {

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -134,7 +134,7 @@ function normalizeIndent(text) {
 /**
  * @param {string} text
  * @param {object} options
- * @param {boolean} options.inline
+ * @param {boolean} [options.inline]
  * @param {boolean} [options.fromHTML]
  */
 export function markdownToHtml(

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -135,14 +135,20 @@ function normalizeIndent(text) {
  * @param {string} text
  * @param {object} options
  * @param {boolean} options.inline
+ * @param {boolean} [options.fromHTML]
  */
-export function markdownToHtml(text, options = { inline: false }) {
+export function markdownToHtml(
+  text,
+  options = { inline: false, fromHTML: true }
+) {
   const normalizedLeftPad = normalizeIndent(text);
   // As markdown is pulled from HTML, > and & are already escaped and
   // so blockquotes aren't picked up by the parser. This fixes it.
-  const potentialMarkdown = normalizedLeftPad
-    .replace(gtEntity, ">")
-    .replace(ampEntity, "&");
+  // When text comes from a raw fetch (data-include), skip this step.
+  const potentialMarkdown =
+    options.fromHTML !== false
+      ? normalizedLeftPad.replace(gtEntity, ">").replace(ampEntity, "&")
+      : normalizedLeftPad;
 
   const result = options.inline
     ? marked.parseInline(potentialMarkdown, config)

--- a/tests/spec/core/data-include-spec.js
+++ b/tests/spec/core/data-include-spec.js
@@ -252,6 +252,37 @@ describe("Core — Data Include", () => {
       expect(doc.getElementById("abstract")).toBeTruthy();
     });
 
+    it("does not unescape HTML entities in raw markdown content", async () => {
+      // When markdown is fetched via data-include, it's raw text (not innerHTML).
+      // The &gt; entity must not be converted to >, or it would create a
+      // blockquote where the author intended literal &gt; text.
+      const includeBody = `
+        ## Test
+
+        &gt; This is not a blockquote.
+
+        > This is a blockquote.
+      `;
+      const body = `<section
+        id="includes"
+        data-include-format="markdown"
+        data-include="${generateDataUrl(includeBody)}"
+      ></section>`;
+
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+
+      // &gt; in raw content must not become a blockquote
+      const p = doc.querySelector("#includes > p");
+      expect(p).toBeTruthy();
+      expect(p.textContent.trim()).toBe("> This is not a blockquote.");
+
+      // Literal > in raw content must still become a blockquote
+      const blockquote = doc.querySelector("#includes > blockquote");
+      expect(blockquote).toBeTruthy();
+      expect(blockquote.textContent.trim()).toBe("This is a blockquote.");
+    });
+
     it("processes markdown with unescaped html code blocks", async () => {
       const includeBody = `
         ## Test


### PR DESCRIPTION
Partially addresses #4096

Skip the &amp;/&gt; entity replacement in markdownToHtml when the
text comes from a raw fetch (data-include) rather than innerHTML.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
