### PR TITLE
feat(core/sortable-table): add click-to-sort table columns with runtime

### DIFF
--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -61,6 +61,7 @@ const modules = [
   import("../src/core/data-type.js"),
   import("../src/core/anchor-expander.js"),
   import("../src/core/dfn-panel.js"),
+  import("../src/core/sortable-table.js"),
   import("../src/core/custom-elements/index.js"),
   import("../src/core/web-monetization.js"),
   import("../src/core/dfn-contract.js"),

--- a/src/core/sortable-table.js
+++ b/src/core/sortable-table.js
@@ -1,8 +1,4 @@
 // @ts-check
-// Module core/sortable-table
-// Adds click-to-sort behaviour to tables with class="sortable".
-// The sort runs in a small runtime script injected into the document so
-// that it is present in saved/exported specs as well as live ReSpec renders.
 import css from "../styles/sortable-table.css.js";
 import { fetchBase } from "./text-loader.js";
 

--- a/src/core/sortable-table.js
+++ b/src/core/sortable-table.js
@@ -1,0 +1,32 @@
+// @ts-check
+// Module core/sortable-table
+// Adds click-to-sort behaviour to tables with class="sortable".
+// The sort runs in a small runtime script injected into the document so
+// that it is present in saved/exported specs as well as live ReSpec renders.
+import css from "../styles/sortable-table.css.js";
+import { fetchBase } from "./text-loader.js";
+
+export const name = "core/sortable-table";
+
+export async function run() {
+  if (!document.querySelector("table.sortable")) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.insertBefore(style, document.querySelector("link"));
+
+  const script = document.createElement("script");
+  script.id = "respec-sortable-table";
+  script.textContent = await loadScript();
+  document.body.append(script);
+}
+
+async function loadScript() {
+  try {
+    return (await import("text!./sortable-table.runtime.js")).default;
+  } catch {
+    return fetchBase("./src/core/sortable-table.runtime.js");
+  }
+}

--- a/src/core/sortable-table.runtime.js
+++ b/src/core/sortable-table.runtime.js
@@ -123,8 +123,8 @@ function setupSortableTable() {
     if (next === null) {
       rows.sort(
         (a, b) =>
-          parseInt(/** @type {string} */ (a.dataset.sortIndex)) -
-          parseInt(/** @type {string} */ (b.dataset.sortIndex))
+          parseInt(/** @type {string} */ (a.dataset.sortIndex), 10) -
+          parseInt(/** @type {string} */ (b.dataset.sortIndex), 10)
       );
     } else {
       /** @type {HTMLTableRowElement | null} */
@@ -137,16 +137,14 @@ function setupSortableTable() {
 
       const isNumeric = rows.every(row => {
         const text = row.cells[colIndex]?.textContent?.trim() ?? "";
-        return text !== "" && !isNaN(parseFloat(text));
+        return text !== "" && !isNaN(Number(text));
       });
 
       const dir = next === ASC ? 1 : -1;
       rows.sort((a, b) => {
         const x = a.cells[colIndex]?.textContent?.trim() ?? "";
         const y = b.cells[colIndex]?.textContent?.trim() ?? "";
-        const cmp = isNumeric
-          ? parseFloat(x) - parseFloat(y)
-          : x.localeCompare(y);
+        const cmp = isNumeric ? Number(x) - Number(y) : x.localeCompare(y);
         return dir * cmp;
       });
     }

--- a/src/core/sortable-table.runtime.js
+++ b/src/core/sortable-table.runtime.js
@@ -122,7 +122,9 @@ function setupSortableTable() {
 
     if (next === null) {
       rows.sort(
-        (a, b) => parseInt(a.dataset.sortIndex) - parseInt(b.dataset.sortIndex)
+        (a, b) =>
+          parseInt(/** @type {string} */ (a.dataset.sortIndex)) -
+          parseInt(/** @type {string} */ (b.dataset.sortIndex))
       );
     } else {
       /** @type {HTMLTableRowElement | null} */

--- a/src/core/sortable-table.runtime.js
+++ b/src/core/sortable-table.runtime.js
@@ -1,0 +1,179 @@
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupSortableTable);
+} else {
+  setupSortableTable();
+}
+
+function setupSortableTable() {
+  /**
+   * Maps each table to a map of th -> current sort direction.
+   * "ascending" | "descending" | null (not sorted)
+   * @type {WeakMap<HTMLTableElement, WeakMap<HTMLTableCellElement, "ascending" | "descending">>}
+   */
+  const STATE = new WeakMap();
+
+  /**
+   * Returns the visible label of the <th> cell, excluding any button text.
+   * @param {HTMLTableCellElement} th
+   * @returns {string}
+   */
+  const getThLabel = th => {
+    return th.dataset.label ?? th.textContent.trim();
+  };
+
+  /**
+   * Creates or updates the sort button inside a <th>.
+   * dir: null = unsorted, "ascending" = A→Z, "descending" = Z→A
+   *
+   * @param {HTMLTableCellElement} th
+   * @param {"ascending" | "descending" | null} dir
+   */
+  const updateButton = (th, dir) => {
+    // Cache the original label on first call so the button text is not
+    // included in subsequent label reads.
+    if (!th.dataset.label) {
+      th.dataset.label = th.textContent.trim();
+    }
+
+    let button = th.querySelector("button");
+    if (!button) {
+      button = document.createElement("button");
+      button.type = "button";
+      th.append(button);
+    }
+
+    const icon = dir === "ascending" ? "▲" : dir === "descending" ? "▼" : "⇕";
+    const label = getThLabel(th);
+
+    if (dir) {
+      button.setAttribute(
+        "aria-label",
+        `Sorted ${dir} by ${label}. Click to sort ${dir === "ascending" ? "descending" : "ascending"}.`
+      );
+    } else {
+      button.setAttribute("aria-label", `Sort by ${label}`);
+    }
+    button.textContent = icon;
+
+    if (dir) {
+      th.setAttribute("aria-sort", dir);
+    } else {
+      th.removeAttribute("aria-sort");
+    }
+  };
+
+  /** @type {NodeListOf<HTMLTableElement>} */
+  const tables = document.querySelectorAll("table.sortable");
+  for (const table of tables) {
+    if (!table.tHead) continue;
+    for (const th of table.tHead.querySelectorAll("th")) {
+      updateButton(th, null);
+    }
+    STATE.set(table, new WeakMap());
+  }
+
+  /**
+   * Returns the <th> that triggered the sort, or null.
+   * Handles both direct clicks on <th> and clicks on the button inside.
+   * @param {MouseEvent} ev
+   * @returns {HTMLTableCellElement | null}
+   */
+  const getTrigger = ev => {
+    if (!(ev.target instanceof HTMLElement)) return null;
+    const th = ev.target.closest("th");
+    if (th instanceof HTMLTableCellElement && th.closest("table.sortable")) {
+      return th;
+    }
+    return null;
+  };
+
+  document.addEventListener("click", ev => {
+    const th = getTrigger(ev);
+    if (!th) return;
+
+    /** @type {HTMLTableElement | null} */
+    const table = th.closest("table.sortable");
+    if (!table || !table.tBodies.length) return;
+
+    let tableState = STATE.get(table);
+    if (!tableState) {
+      tableState = new WeakMap();
+      STATE.set(table, tableState);
+    }
+
+    const current = tableState.get(th) ?? null;
+    // Toggle: null→ascending, ascending→descending, descending→null (reset)
+    /** @type {"ascending" | "descending" | null} */
+    const next =
+      current === null
+        ? "ascending"
+        : current === "ascending"
+          ? "descending"
+          : null;
+
+    // Reset all other headers in this table
+    if (table.tHead) {
+      for (const otherTh of table.tHead.querySelectorAll("th")) {
+        if (otherTh !== th) {
+          tableState.delete(otherTh);
+          updateButton(otherTh, null);
+        }
+      }
+    }
+
+    if (next === null) {
+      tableState.delete(th);
+    } else {
+      tableState.set(th, next);
+    }
+    updateButton(th, next);
+
+    const tbody = table.tBodies[0];
+    /** @type {HTMLTableRowElement[]} */
+    const rows = Array.from(tbody.rows);
+
+    if (next === null) {
+      // Restore original order — rows carry their original index
+      rows.sort(
+        (a, b) =>
+          (a.dataset.sortIndex ? parseInt(a.dataset.sortIndex) : 0) -
+          (b.dataset.sortIndex ? parseInt(b.dataset.sortIndex) : 0)
+      );
+    } else {
+      // Record original order on first sort
+      rows.forEach((row, i) => {
+        if (!row.dataset.sortIndex) {
+          row.dataset.sortIndex = String(i);
+        }
+      });
+
+      /** @type {HTMLTableRowElement | null} */
+      const headerRow = /** @type {HTMLTableRowElement | null} */ (
+        th.closest("tr")
+      );
+      if (!headerRow) return;
+      const colIndex = Array.from(headerRow.cells).indexOf(th);
+      if (colIndex === -1) return;
+
+      rows.sort((a, b) => {
+        const x = a.cells[colIndex]?.textContent?.trim() ?? "";
+        const y = b.cells[colIndex]?.textContent?.trim() ?? "";
+
+        // Numeric sort when both cells look like numbers
+        const numX = parseFloat(x);
+        const numY = parseFloat(y);
+        if (!isNaN(numX) && !isNaN(numY)) {
+          return next === "ascending" ? numX - numY : numY - numX;
+        }
+
+        return next === "ascending" ? x.localeCompare(y) : y.localeCompare(x);
+      });
+    }
+
+    /** @type {typeof tbody} */
+    const newTbody = tbody.cloneNode(false);
+    newTbody.append(...rows);
+    tbody.replaceWith(newTbody);
+  });
+}

--- a/src/core/sortable-table.runtime.js
+++ b/src/core/sortable-table.runtime.js
@@ -6,32 +6,21 @@ if (document.respec) {
 }
 
 function setupSortableTable() {
-  /**
-   * Maps each table to a map of th -> current sort direction.
-   * "ascending" | "descending" | null (not sorted)
-   * @type {WeakMap<HTMLTableElement, WeakMap<HTMLTableCellElement, "ascending" | "descending">>}
-   */
+  const ASC = "ascending";
+  const DESC = "descending";
+
+  /** @type {Record<string, "ascending" | "descending" | null>} */
+  const NEXT_DIR = { [ASC]: DESC, [DESC]: null };
+
+  /** @type {WeakMap<HTMLTableElement, WeakMap<HTMLTableCellElement, "ascending" | "descending">>} */
   const STATE = new WeakMap();
 
   /**
-   * Returns the visible label of the <th> cell, excluding any button text.
-   * @param {HTMLTableCellElement} th
-   * @returns {string}
-   */
-  const getThLabel = th => {
-    return th.dataset.label ?? th.textContent.trim();
-  };
-
-  /**
-   * Creates or updates the sort button inside a <th>.
-   * dir: null = unsorted, "ascending" = A→Z, "descending" = Z→A
-   *
    * @param {HTMLTableCellElement} th
    * @param {"ascending" | "descending" | null} dir
    */
   const updateButton = (th, dir) => {
-    // Cache the original label on first call so the button text is not
-    // included in subsequent label reads.
+    // Cache original label before button text is appended.
     if (!th.dataset.label) {
       th.dataset.label = th.textContent.trim();
     }
@@ -43,39 +32,31 @@ function setupSortableTable() {
       th.append(button);
     }
 
-    const icon = dir === "ascending" ? "▲" : dir === "descending" ? "▼" : "⇕";
-    const label = getThLabel(th);
+    const icon = dir === ASC ? "▲" : dir === DESC ? "▼" : "⇕";
+    const label = th.dataset.label;
 
     if (dir) {
+      const opposite = dir === ASC ? DESC : ASC;
       button.setAttribute(
         "aria-label",
-        `Sorted ${dir} by ${label}. Click to sort ${dir === "ascending" ? "descending" : "ascending"}.`
+        `Sorted ${dir} by ${label}. Click to sort ${opposite}.`
       );
-    } else {
-      button.setAttribute("aria-label", `Sort by ${label}`);
-    }
-    button.textContent = icon;
-
-    if (dir) {
       th.setAttribute("aria-sort", dir);
     } else {
+      button.setAttribute("aria-label", `Sort by ${label}`);
       th.removeAttribute("aria-sort");
     }
+    button.textContent = icon;
   };
 
   /** @type {NodeListOf<HTMLTableElement>} */
   const tables = document.querySelectorAll("table.sortable");
-  for (const table of tables) {
-    if (!table.tHead) continue;
-    for (const th of table.tHead.querySelectorAll("th")) {
-      updateButton(th, null);
-    }
-    STATE.set(table, new WeakMap());
-  }
+  tables.forEach(table => {
+    if (!table.tHead) return;
+    table.tHead.querySelectorAll("th").forEach(th => updateButton(th, null));
+  });
 
   /**
-   * Returns the <th> that triggered the sort, or null.
-   * Handles both direct clicks on <th> and clicks on the button inside.
    * @param {MouseEvent} ev
    * @returns {HTMLTableCellElement | null}
    */
@@ -86,6 +67,18 @@ function setupSortableTable() {
       return th;
     }
     return null;
+  };
+
+  /**
+   * Stamps original row indices so the table can be reset to its initial order.
+   * @param {HTMLTableRowElement[]} rows
+   */
+  const stampOriginalOrder = rows => {
+    rows.forEach((row, i) => {
+      if (!row.dataset.sortIndex) {
+        row.dataset.sortIndex = String(i);
+      }
+    });
   };
 
   document.addEventListener("click", ev => {
@@ -103,23 +96,16 @@ function setupSortableTable() {
     }
 
     const current = tableState.get(th) ?? null;
-    // Toggle: null→ascending, ascending→descending, descending→null (reset)
     /** @type {"ascending" | "descending" | null} */
-    const next =
-      current === null
-        ? "ascending"
-        : current === "ascending"
-          ? "descending"
-          : null;
+    const next = current === null ? ASC : NEXT_DIR[current];
 
-    // Reset all other headers in this table
     if (table.tHead) {
-      for (const otherTh of table.tHead.querySelectorAll("th")) {
+      table.tHead.querySelectorAll("th").forEach(otherTh => {
         if (otherTh !== th) {
           tableState.delete(otherTh);
           updateButton(otherTh, null);
         }
-      }
+      });
     }
 
     if (next === null) {
@@ -132,22 +118,13 @@ function setupSortableTable() {
     const tbody = table.tBodies[0];
     /** @type {HTMLTableRowElement[]} */
     const rows = Array.from(tbody.rows);
+    stampOriginalOrder(rows);
 
     if (next === null) {
-      // Restore original order — rows carry their original index
       rows.sort(
-        (a, b) =>
-          (a.dataset.sortIndex ? parseInt(a.dataset.sortIndex) : 0) -
-          (b.dataset.sortIndex ? parseInt(b.dataset.sortIndex) : 0)
+        (a, b) => parseInt(a.dataset.sortIndex) - parseInt(b.dataset.sortIndex)
       );
     } else {
-      // Record original order on first sort
-      rows.forEach((row, i) => {
-        if (!row.dataset.sortIndex) {
-          row.dataset.sortIndex = String(i);
-        }
-      });
-
       /** @type {HTMLTableRowElement | null} */
       const headerRow = /** @type {HTMLTableRowElement | null} */ (
         th.closest("tr")
@@ -156,24 +133,25 @@ function setupSortableTable() {
       const colIndex = Array.from(headerRow.cells).indexOf(th);
       if (colIndex === -1) return;
 
+      const isNumeric = rows.every(row => {
+        const text = row.cells[colIndex]?.textContent?.trim() ?? "";
+        return text !== "" && !isNaN(parseFloat(text));
+      });
+
+      const dir = next === ASC ? 1 : -1;
       rows.sort((a, b) => {
         const x = a.cells[colIndex]?.textContent?.trim() ?? "";
         const y = b.cells[colIndex]?.textContent?.trim() ?? "";
-
-        // Numeric sort when both cells look like numbers
-        const numX = parseFloat(x);
-        const numY = parseFloat(y);
-        if (!isNaN(numX) && !isNaN(numY)) {
-          return next === "ascending" ? numX - numY : numY - numX;
-        }
-
-        return next === "ascending" ? x.localeCompare(y) : y.localeCompare(x);
+        const cmp = isNumeric
+          ? parseFloat(x) - parseFloat(y)
+          : x.localeCompare(y);
+        return dir * cmp;
       });
     }
 
     /** @type {typeof tbody} */
     const newTbody = tbody.cloneNode(false);
-    newTbody.append(...rows);
+    for (const row of rows) newTbody.append(row);
     tbody.replaceWith(newTbody);
   });
 }

--- a/src/styles/sortable-table.css.js
+++ b/src/styles/sortable-table.css.js
@@ -1,0 +1,31 @@
+const css = String.raw;
+
+// prettier-ignore
+export default css`
+  .sortable th {
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
+  .sortable th button {
+    background: transparent;
+    color: inherit;
+    border: none;
+    font-size: 0.7em;
+    padding: 0 0.3em;
+    cursor: pointer;
+    opacity: 0.5;
+    vertical-align: middle;
+  }
+
+  .sortable th button:hover,
+  .sortable th button:focus {
+    opacity: 1;
+    outline: 1px solid;
+  }
+
+  .sortable th[aria-sort="ascending"] button,
+  .sortable th[aria-sort="descending"] button {
+    opacity: 1;
+  }
+`;

--- a/tests/spec/core/sortable-table-spec.js
+++ b/tests/spec/core/sortable-table-spec.js
@@ -1,0 +1,196 @@
+"use strict";
+
+import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
+
+describe("Core — sortable-table", () => {
+  afterAll(flushIframes);
+
+  /**
+   * Helper: dispatch a click event on an element inside the doc.
+   * @param {HTMLElement} el
+   */
+  function click(el) {
+    el.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true })
+    );
+  }
+
+  // Table used in most tests
+  const sortableBody = `
+    <section>
+      <h2>Test Section</h2>
+      <table class="sortable">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>Charlie</td><td>3</td></tr>
+          <tr><td>Alice</td><td>1</td></tr>
+          <tr><td>Bob</td><td>2</td></tr>
+        </tbody>
+      </table>
+    </section>
+  `;
+
+  describe("module bootstrap", () => {
+    it("does not run when no sortable table is present", async () => {
+      const body = `<table><tr><td>plain table</td></tr></table>`;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const script = doc.getElementById("respec-sortable-table");
+      expect(script).toBeNull();
+    });
+
+    it("injects the runtime script when a sortable table exists", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const script = doc.getElementById("respec-sortable-table");
+      expect(script).not.toBeNull();
+    });
+
+    it("injects a <style> element for sortable-table CSS", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      // The style element is injected into <head>; check it contains our marker class.
+      const headStyles = [...doc.querySelectorAll("head style")];
+      const found = headStyles.some(s => s.textContent.includes(".sortable"));
+      expect(found).toBeTrue();
+    });
+  });
+
+  describe("sort buttons", () => {
+    it("adds a sort button to each <th> in the sortable table", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const ths = doc.querySelectorAll("table.sortable thead th");
+      for (const th of ths) {
+        const btn = th.querySelector("button");
+        expect(btn).not.toBeNull();
+      }
+    });
+
+    it("buttons start with aria-label 'Sort by <column>'", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const ths = [...doc.querySelectorAll("table.sortable thead th")];
+      const btn0 = ths[0].querySelector("button");
+      expect(btn0.getAttribute("aria-label")).toBe("Sort by Name");
+    });
+
+    it("does not add sort buttons to non-sortable tables", async () => {
+      const body = `
+        ${sortableBody}
+        <table class="plain">
+          <thead><tr><th>Foo</th></tr></thead>
+          <tbody><tr><td>bar</td></tr></tbody>
+        </table>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const plainThBtn = doc.querySelector("table.plain thead th button");
+      expect(plainThBtn).toBeNull();
+    });
+  });
+
+  describe("aria-sort attribute", () => {
+    it("has no aria-sort before any click", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const th = doc.querySelector("table.sortable thead th");
+      expect(th.hasAttribute("aria-sort")).toBeFalse();
+    });
+
+    it("sets aria-sort='ascending' after first click", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const th = doc.querySelector("table.sortable thead th");
+      click(th.querySelector("button"));
+      expect(th.getAttribute("aria-sort")).toBe("ascending");
+    });
+
+    it("sets aria-sort='descending' after second click", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const th = doc.querySelector("table.sortable thead th");
+      const btn = th.querySelector("button");
+      click(btn);
+      click(btn);
+      expect(th.getAttribute("aria-sort")).toBe("descending");
+    });
+
+    it("removes aria-sort and restores order after third click", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const th = doc.querySelector("table.sortable thead th");
+      const btn = th.querySelector("button");
+      click(btn);
+      click(btn);
+      click(btn);
+      expect(th.hasAttribute("aria-sort")).toBeFalse();
+    });
+
+    it("resets aria-sort on other columns when a new column is clicked", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const [th0, th1] = doc.querySelectorAll("table.sortable thead th");
+      click(th0.querySelector("button"));
+      expect(th0.getAttribute("aria-sort")).toBe("ascending");
+      click(th1.querySelector("button"));
+      expect(th1.getAttribute("aria-sort")).toBe("ascending");
+      expect(th0.hasAttribute("aria-sort")).toBeFalse();
+    });
+  });
+
+  describe("text sort", () => {
+    it("sorts rows ascending (A→Z) on first click", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const th = doc.querySelector("table.sortable thead th");
+      click(th.querySelector("button"));
+      const rows = [...doc.querySelectorAll("table.sortable tbody tr")];
+      const names = rows.map(r => r.cells[0].textContent.trim());
+      expect(names).toEqual(["Alice", "Bob", "Charlie"]);
+    });
+
+    it("sorts rows descending (Z→A) on second click", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const th = doc.querySelector("table.sortable thead th");
+      const btn = th.querySelector("button");
+      click(btn);
+      click(btn);
+      const rows = [...doc.querySelectorAll("table.sortable tbody tr")];
+      const names = rows.map(r => r.cells[0].textContent.trim());
+      expect(names).toEqual(["Charlie", "Bob", "Alice"]);
+    });
+
+    it("restores original row order on third click (reset)", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const th = doc.querySelector("table.sortable thead th");
+      const btn = th.querySelector("button");
+      click(btn);
+      click(btn);
+      click(btn);
+      const rows = [...doc.querySelectorAll("table.sortable tbody tr")];
+      const names = rows.map(r => r.cells[0].textContent.trim());
+      expect(names).toEqual(["Charlie", "Alice", "Bob"]);
+    });
+  });
+
+  describe("numeric sort", () => {
+    it("sorts numeric columns by numeric value, not lexicographic order", async () => {
+      const ops = makeStandardOps(null, sortableBody);
+      const doc = await makeRSDoc(ops);
+      const ths = [...doc.querySelectorAll("table.sortable thead th")];
+      const scoreBtn = ths[1].querySelector("button");
+      click(scoreBtn);
+      const rows = [...doc.querySelectorAll("table.sortable tbody tr")];
+      const scores = rows.map(r => r.cells[1].textContent.trim());
+      expect(scores).toEqual(["1", "2", "3"]);
+    });
+  });
+});

--- a/tests/spec/core/sortable-table-spec.js
+++ b/tests/spec/core/sortable-table-spec.js
@@ -6,7 +6,6 @@ describe("Core — sortable-table", () => {
   afterAll(flushIframes);
 
   /**
-   * Helper: dispatch a click event on an element inside the doc.
    * @param {HTMLElement} el
    */
   function click(el) {
@@ -15,7 +14,15 @@ describe("Core — sortable-table", () => {
     );
   }
 
-  // Table used in most tests
+  /**
+   * The runtime defers setup via document.respec.ready.then(), so we must
+   * flush the iframe's pending microtasks before interacting with buttons.
+   * @param {Document} doc
+   */
+  async function flushRuntime(doc) {
+    await new Promise(r => doc.defaultView.setTimeout(r, 0));
+  }
+
   const sortableBody = `
     <section>
       <h2>Test Section</h2>
@@ -54,7 +61,6 @@ describe("Core — sortable-table", () => {
     it("injects a <style> element for sortable-table CSS", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
-      // The style element is injected into <head>; check it contains our marker class.
       const headStyles = [...doc.querySelectorAll("head style")];
       const found = headStyles.some(s => s.textContent.includes(".sortable"));
       expect(found).toBeTrue();
@@ -65,6 +71,7 @@ describe("Core — sortable-table", () => {
     it("adds a sort button to each <th> in the sortable table", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const ths = doc.querySelectorAll("table.sortable thead th");
       for (const th of ths) {
         const btn = th.querySelector("button");
@@ -75,6 +82,7 @@ describe("Core — sortable-table", () => {
     it("buttons start with aria-label 'Sort by <column>'", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const ths = [...doc.querySelectorAll("table.sortable thead th")];
       const btn0 = ths[0].querySelector("button");
       expect(btn0.getAttribute("aria-label")).toBe("Sort by Name");
@@ -90,6 +98,7 @@ describe("Core — sortable-table", () => {
       `;
       const ops = makeStandardOps(null, body);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const plainThBtn = doc.querySelector("table.plain thead th button");
       expect(plainThBtn).toBeNull();
     });
@@ -99,6 +108,7 @@ describe("Core — sortable-table", () => {
     it("has no aria-sort before any click", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const th = doc.querySelector("table.sortable thead th");
       expect(th.hasAttribute("aria-sort")).toBeFalse();
     });
@@ -106,6 +116,7 @@ describe("Core — sortable-table", () => {
     it("sets aria-sort='ascending' after first click", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const th = doc.querySelector("table.sortable thead th");
       click(th.querySelector("button"));
       expect(th.getAttribute("aria-sort")).toBe("ascending");
@@ -114,6 +125,7 @@ describe("Core — sortable-table", () => {
     it("sets aria-sort='descending' after second click", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const th = doc.querySelector("table.sortable thead th");
       const btn = th.querySelector("button");
       click(btn);
@@ -124,6 +136,7 @@ describe("Core — sortable-table", () => {
     it("removes aria-sort and restores order after third click", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const th = doc.querySelector("table.sortable thead th");
       const btn = th.querySelector("button");
       click(btn);
@@ -135,6 +148,7 @@ describe("Core — sortable-table", () => {
     it("resets aria-sort on other columns when a new column is clicked", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const [th0, th1] = doc.querySelectorAll("table.sortable thead th");
       click(th0.querySelector("button"));
       expect(th0.getAttribute("aria-sort")).toBe("ascending");
@@ -148,6 +162,7 @@ describe("Core — sortable-table", () => {
     it("sorts rows ascending (A→Z) on first click", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const th = doc.querySelector("table.sortable thead th");
       click(th.querySelector("button"));
       const rows = [...doc.querySelectorAll("table.sortable tbody tr")];
@@ -158,6 +173,7 @@ describe("Core — sortable-table", () => {
     it("sorts rows descending (Z→A) on second click", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const th = doc.querySelector("table.sortable thead th");
       const btn = th.querySelector("button");
       click(btn);
@@ -170,6 +186,7 @@ describe("Core — sortable-table", () => {
     it("restores original row order on third click (reset)", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const th = doc.querySelector("table.sortable thead th");
       const btn = th.querySelector("button");
       click(btn);
@@ -185,6 +202,7 @@ describe("Core — sortable-table", () => {
     it("sorts numeric columns by numeric value, not lexicographic order", async () => {
       const ops = makeStandardOps(null, sortableBody);
       const doc = await makeRSDoc(ops);
+      await flushRuntime(doc);
       const ths = [...doc.querySelectorAll("table.sortable thead th")];
       const scoreBtn = ths[1].querySelector("button");
       click(scoreBtn);


### PR DESCRIPTION
Closes https://github.com/speced/respec/issues/3483

Adds a `class="sortable"` opt-in for tables. Each `<th>` gets a sort button (⇕/▲/▼) with aria-sort attributes. Clicking cycles through ascending, descending, and original order. Numeric columns are detected automatically and sorted by value, not lexicographically. The sort runtime is injected as a `<script>` so it persists in exported/saved specs.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
