### PR TITLE
feat(implementation-status): loading UX and accessibility

### DIFF
--- a/src/core/implementation-status.js
+++ b/src/core/implementation-status.js
@@ -191,7 +191,7 @@ export async function run(conf) {
     conf.implementationStatus
   );
   const headDlElem = document.querySelector(".head dl");
-  if (!headDlElem) return;
+  if (!headDlElem || !headDlElem.parentElement) return;
 
   const dt = html`<dt class="baseline-title">Browser support:</dt>`;
   const dd = html`<dd
@@ -207,26 +207,24 @@ export async function run(conf) {
   ></span>`;
 
   headDlElem.append(dt, dd);
-  /** @type {HTMLElement} */ (headDlElem.parentElement).append(summary);
+  headDlElem.parentElement.append(summary);
 
   let resolvedResult;
   try {
     resolvedResult = await fetchAndRender(conf, options);
+    dd.classList.remove("baseline-status--loading");
+    dd.classList.add("baseline-status--loaded");
+    dd.removeAttribute("aria-busy");
+    html.bind(dd)`${resolvedResult.content}`;
+    if (resolvedResult.summary) {
+      summary.textContent = resolvedResult.summary;
+    }
   } catch (err) {
     resolvedResult = handleError(err);
     dd.classList.remove("baseline-status--loading");
     dd.removeAttribute("aria-busy");
     html.bind(dd)`${resolvedResult.content}`;
     summary.textContent = "Browser support data unavailable.";
-    return;
-  }
-
-  dd.classList.remove("baseline-status--loading");
-  dd.classList.add("baseline-status--loaded");
-  dd.removeAttribute("aria-busy");
-  html.bind(dd)`${resolvedResult.content}`;
-  if (resolvedResult.summary) {
-    summary.textContent = resolvedResult.summary;
   }
 
   sub(
@@ -307,7 +305,7 @@ async function fetchAndRender(conf, options) {
   }
 
   const baseline = computeAggregate(features);
-  const statusText = STATUS_TEXT.get(baseline);
+  const statusText = /** @type {string} */ (STATUS_TEXT.get(baseline));
   const support = aggregateSupport(features);
 
   pub("amend-user-config", { implementationStatus: options.feature || true });
@@ -482,7 +480,7 @@ function getLogoSrc(browserId) {
 
 /**
  * @param {"high" | "low" | ""} baseline
- * @param {string | undefined} statusText
+ * @param {string} statusText
  * @param {Map<string, boolean>} support
  * @param {WebFeatureEntry[]} features
  */

--- a/src/core/implementation-status.js
+++ b/src/core/implementation-status.js
@@ -152,9 +152,10 @@ const BROWSER_GROUPS = Map.groupBy(
 
 function fallbackResult() {
   return {
-    dt: html`Implementation status:`,
-    dd: html`<a href="https://webstatus.dev/">Web Platform Status</a>`,
+    content: html`<a href="https://webstatus.dev/">Web Platform Status</a>`,
     moreInfoUrl: "https://webstatus.dev/",
+    summary: "",
+    featureName: "",
   };
 }
 
@@ -173,6 +174,13 @@ export function prepare(conf) {
       ${css}
     </style>`
   );
+  const preconnect = html`<link
+    rel="preconnect"
+    href="https://www.w3.org"
+    crossorigin
+    class="${options.removeOnSave ? "removeOnSave" : ""}"
+  />`;
+  document.head.appendChild(preconnect);
 }
 
 /** @param {RespecConfig} conf */
@@ -185,32 +193,71 @@ export async function run(conf) {
   const headDlElem = document.querySelector(".head dl");
   if (!headDlElem) return;
 
-  const result = fetchAndRender(conf, options).catch(handleError);
+  const dt = html`<dt class="baseline-title">Browser support:</dt>`;
+  const dd = html`<dd
+    class="baseline-status baseline-status--loading"
+    aria-busy="true"
+  >
+    Checking browser support…
+  </dd>`;
+  const summary = html`<span
+    class="baseline-a11y-summary"
+    aria-live="polite"
+    aria-atomic="true"
+  ></span>`;
 
-  const dtPromise = result.then(r => r.dt);
-  const ddPromise = result.then(r => r.dd);
+  headDlElem.append(dt, dd);
+  /** @type {HTMLElement} */ (headDlElem.parentElement).append(summary);
 
-  const definitionPair = html`<dt class="baseline-title">
-      ${{ any: dtPromise, placeholder: "Implementation status:" }}
-    </dt>
-    <dd class="baseline-status">
-      ${{ any: ddPromise, placeholder: "Checking availability..." }}
-    </dd>`;
-  headDlElem.append(...definitionPair.childNodes);
-
-  const rendered = await result;
-
-  if (options.removeOnSave) {
-    const savedUrl = rendered.moreInfoUrl || "https://webstatus.dev/";
-    sub(
-      "beforesave",
-      /** @param {Document} outputDoc */ outputDoc => {
-        const dd = outputDoc.querySelector(".baseline-status");
-        if (!dd) return;
-        html.bind(dd)`<a href="${savedUrl}">Web Platform Status</a>`;
-      }
-    );
+  let resolvedResult;
+  try {
+    resolvedResult = await fetchAndRender(conf, options);
+  } catch (err) {
+    resolvedResult = handleError(err);
+    dd.classList.remove("baseline-status--loading");
+    dd.removeAttribute("aria-busy");
+    html.bind(dd)`${resolvedResult.content}`;
+    summary.textContent = "Browser support data unavailable.";
+    return;
   }
+
+  dd.classList.remove("baseline-status--loading");
+  dd.classList.add("baseline-status--loaded");
+  dd.removeAttribute("aria-busy");
+  html.bind(dd)`${resolvedResult.content}`;
+  if (resolvedResult.summary) {
+    summary.textContent = resolvedResult.summary;
+  }
+
+  sub(
+    "beforesave",
+    /** @param {Document} outputDoc */ outputDoc => {
+      const savedDd = outputDoc.querySelector(".baseline-status");
+      if (!savedDd) return;
+
+      savedDd.classList.remove(
+        "baseline-status--loading",
+        "baseline-status--loaded"
+      );
+      savedDd.removeAttribute("aria-busy");
+      outputDoc.querySelector(".baseline-a11y-summary")?.remove();
+
+      if (options.removeOnSave) {
+        const savedUrl = resolvedResult.moreInfoUrl || "https://webstatus.dev/";
+        html.bind(savedDd)`<a href="${savedUrl}">Web Platform Status</a>`;
+      } else {
+        const moreInfoLink = savedDd.querySelector(".baseline-more-info");
+        if (moreInfoLink) {
+          const featureName = resolvedResult.featureName || "browser support";
+          moreInfoLink.textContent = "Current browser support";
+          moreInfoLink.setAttribute(
+            "aria-label",
+            `Current browser support for ${featureName} on webstatus.dev`
+          );
+        }
+      }
+    }
+  );
 }
 
 /** @param {unknown} err */
@@ -492,9 +539,20 @@ function renderBadge(baseline, statusText, support, features) {
   const moreInfoLabel = singleFeature?.name
     ? `More info about ${singleFeature.name} support`
     : "More info about browser support";
+  const featureName = singleFeature?.name || "";
 
-  const dt = html`${statusText}:${icon}`;
-  const dd = html`${browserGroup}
+  const supportedBrowsers = [...support.entries()]
+    .filter(([, supported]) => supported)
+    .map(([id]) => BROWSERS.get(id)?.name || id);
+
+  const summary = `${featureName || "This feature"}: ${statusText}. ${
+    supportedBrowsers.length
+      ? `Supported in ${supportedBrowsers.join(", ")}.`
+      : "Limited browser support."
+  }`;
+
+  const content = html`<span class="baseline-status-label">${statusText}:</span
+    >${icon}${browserGroup}
     <a
       class="baseline-more-info"
       href="${moreInfoUrl}"
@@ -502,5 +560,5 @@ function renderBadge(baseline, statusText, support, features) {
       >More info</a
     >`;
 
-  return { dt, dd, moreInfoUrl };
+  return { content, moreInfoUrl, summary, featureName };
 }

--- a/src/styles/implementation-status.css.js
+++ b/src/styles/implementation-status.css.js
@@ -93,8 +93,10 @@ export default css`
   50% { opacity: 0.35; }
 }
 
-.baseline-status--loaded {
-  animation: baseline-appear 200ms cubic-bezier(0, 0, 0.2, 1) both;
+@media (prefers-reduced-motion: no-preference) {
+  .baseline-status--loaded {
+    animation: baseline-appear 200ms cubic-bezier(0, 0, 0.2, 1) both;
+  }
 }
 
 @keyframes baseline-appear {

--- a/src/styles/implementation-status.css.js
+++ b/src/styles/implementation-status.css.js
@@ -73,6 +73,48 @@ export default css`
   white-space: nowrap;
 }
 
+/* Loading state */
+.baseline-status--loading {
+  min-height: 32px;
+  opacity: 0.6;
+  will-change: opacity;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .baseline-status--loading {
+    animation: baseline-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    animation-delay: 300ms;
+    animation-fill-mode: backwards;
+  }
+}
+
+@keyframes baseline-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 0.35; }
+}
+
+.baseline-status--loaded {
+  animation: baseline-appear 200ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+@keyframes baseline-appear {
+  from { opacity: 0.6; }
+  to { opacity: 1; }
+}
+
+/* Visually hidden live region for screen readers */
+.baseline-a11y-summary {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
   .baseline-pill.supported {
@@ -93,6 +135,11 @@ export default css`
 }
 
 @media print {
+  .baseline-status--loading {
+    animation: none;
+    opacity: 1;
+  }
+
   .baseline-pill {
     background: none !important;
     border: 1px solid #ccc;

--- a/tests/spec/core/implementation-status-spec.js
+++ b/tests/spec/core/implementation-status-spec.js
@@ -37,7 +37,8 @@ describe("Core — Implementation Status", () => {
 
     expect(dt).toBeTruthy();
     expect(dd).toBeTruthy();
-    expect(dt.textContent).toContain("Widely available");
+    expect(dt.textContent).toContain("Browser support");
+    expect(dd.textContent).toContain("Widely available");
   });
 
   it("shows correct status for limited availability", async () => {
@@ -48,10 +49,10 @@ describe("Core — Implementation Status", () => {
       },
     });
     const doc = await makeRSDoc(ops);
-    const dt = doc.querySelector(".baseline-title");
+    const dd = doc.querySelector(".baseline-status");
 
-    expect(dt).toBeTruthy();
-    expect(dt.textContent).toContain("Limited availability");
+    expect(dd).toBeTruthy();
+    expect(dd.textContent).toContain("Limited availability");
   });
 
   it("shows browser support icons", async () => {
@@ -87,7 +88,6 @@ describe("Core — Implementation Status", () => {
 
     expect(supported.length).toBe(1);
     expect(notSupported.length).toBe(3);
-    // Each unsupported browser must have its own SVG icon (not shared)
     for (const el of notSupported) {
       expect(el.querySelector(".baseline-support-icon")).toBeTruthy();
     }
@@ -101,10 +101,10 @@ describe("Core — Implementation Status", () => {
       },
     });
     const doc = await makeRSDoc(ops);
-    const dt = doc.querySelector(".baseline-title");
+    const dd = doc.querySelector(".baseline-status");
 
-    expect(dt).toBeTruthy();
-    expect(dt.textContent).toContain("Widely available");
+    expect(dd).toBeTruthy();
+    expect(dd.textContent).toContain("Widely available");
   });
 
   it("aggregates multiple features with worst-of semantics", async () => {
@@ -115,10 +115,10 @@ describe("Core — Implementation Status", () => {
       },
     });
     const doc = await makeRSDoc(ops);
-    const dt = doc.querySelector(".baseline-title");
+    const dd = doc.querySelector(".baseline-status");
 
-    expect(dt).toBeTruthy();
-    expect(dt.textContent).toContain("Newly available");
+    expect(dd).toBeTruthy();
+    expect(dd.textContent).toContain("Newly available");
   });
 
   it("handles missing feature gracefully", async () => {
@@ -161,10 +161,10 @@ describe("Core — Implementation Status", () => {
       },
     });
     const doc = await makeRSDoc(ops);
-    const dt = doc.querySelector(".baseline-title");
+    const dd = doc.querySelector(".baseline-status");
 
-    expect(dt).toBeTruthy();
-    expect(dt.textContent).toContain("Newly available");
+    expect(dd).toBeTruthy();
+    expect(dd.textContent).toContain("Newly available");
   });
 
   it("groups browsers by engine in pills", async () => {
@@ -240,7 +240,6 @@ describe("Core — Implementation Status", () => {
     const dd = doc.querySelector(".baseline-status");
 
     expect(dd).toBeTruthy();
-    // Badge should have browser pills, not just a plain link
     expect(dd.querySelector(".baseline-browsers")).toBeTruthy();
   });
 
@@ -290,10 +289,10 @@ describe("Core — Implementation Status", () => {
       },
     });
     const doc = await makeRSDoc(ops);
-    const dt = doc.querySelector(".baseline-title");
+    const dd = doc.querySelector(".baseline-status");
 
-    expect(dt).toBeTruthy();
-    expect(dt.textContent).toContain("Widely available");
+    expect(dd).toBeTruthy();
+    expect(dd.textContent).toContain("Widely available");
   });
 
   it("ignores split features in auto-detect", async () => {
@@ -304,10 +303,10 @@ describe("Core — Implementation Status", () => {
       },
     });
     const doc = await makeRSDoc(ops);
-    const dt = doc.querySelector(".baseline-title");
+    const dd = doc.querySelector(".baseline-status");
 
-    expect(dt).toBeTruthy();
-    expect(dt.textContent).toContain("Newly available");
+    expect(dd).toBeTruthy();
+    expect(dd.textContent).toContain("Newly available");
   });
 
   it("ignores moved features when looking up explicit feature ID", async () => {
@@ -324,5 +323,141 @@ describe("Core — Implementation Status", () => {
 
     expect(warnings).toHaveSize(1);
     expect(warnings[0].message).toContain("No Baseline data found");
+  });
+
+  describe("loading state and accessibility", () => {
+    it("removes loading class after render", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const dd = doc.querySelector(".baseline-status");
+
+      expect(dd).toBeTruthy();
+      expect(dd.classList.contains("baseline-status--loading")).toBeFalse();
+      expect(dd.classList.contains("baseline-status--loaded")).toBeTrue();
+    });
+
+    it("removes aria-busy after render", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const dd = doc.querySelector(".baseline-status");
+
+      expect(dd).toBeTruthy();
+      expect(dd.hasAttribute("aria-busy")).toBeFalse();
+    });
+
+    it("populates the accessibility summary after render", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const summary = doc.querySelector(".baseline-a11y-summary");
+
+      expect(summary).toBeTruthy();
+      expect(summary.getAttribute("aria-live")).toBe("polite");
+      expect(summary.getAttribute("aria-atomic")).toBe("true");
+      expect(summary.textContent).toContain("Widely available");
+      expect(summary.textContent).toContain("Supported in");
+    });
+
+    it("uses static dt label 'Browser support:'", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const dt = doc.querySelector(".baseline-title");
+
+      expect(dt.textContent.trim()).toBe("Browser support:");
+    });
+
+    it("includes status label in the dd element", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const label = doc.querySelector(".baseline-status-label");
+
+      expect(label).toBeTruthy();
+      expect(label.textContent).toContain("Widely available");
+    });
+
+    it("adds preconnect link for browser logos", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const preconnect = doc.querySelector(
+        'link[rel="preconnect"][href="https://www.w3.org"]'
+      );
+
+      expect(preconnect).toBeTruthy();
+    });
+
+    it("removes a11y summary span from exported document", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const exportedDoc = await getExportedDoc(doc);
+
+      expect(exportedDoc.querySelector(".baseline-a11y-summary")).toBeNull();
+    });
+
+    it("removes loading classes from exported document", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const exportedDoc = await getExportedDoc(doc);
+      const dd = exportedDoc.querySelector(".baseline-status");
+
+      expect(dd.classList.contains("baseline-status--loading")).toBeFalse();
+      expect(dd.classList.contains("baseline-status--loaded")).toBeFalse();
+      expect(dd.hasAttribute("aria-busy")).toBeFalse();
+    });
+
+    it("changes 'More info' to 'Current browser support' in exported doc", async () => {
+      const ops = makeStandardOps({
+        implementationStatus: {
+          feature: "test-feature",
+          apiURL,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+      const exportedDoc = await getExportedDoc(doc);
+      const link = exportedDoc.querySelector(".baseline-more-info");
+
+      expect(link.textContent).toBe("Current browser support");
+      expect(link.getAttribute("aria-label")).toContain(
+        "Current browser support for"
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #5296

Improves the Baseline implementation status widget with loading animation, accessibility, and saved-document behavior per the agreement in w3c/vibration#63.

**Loading animation:** 300ms delay (avoids flash on fast loads), subtle opacity pulse (0.35–0.6 range), progressive enhancement via `prefers-reduced-motion: no-preference`, CLS reservation via `min-height`.

**Accessibility:** Dedicated visually-hidden `aria-live` region with concise summary string for reliable cross-AT announcements. Static "Browser support:" dt label with dynamic status in dd (proper live region scoping). `aria-atomic="true"` for coherent announcements.

**Saved documents:** "More info" link becomes "Current browser support" in exported HTML (noun phrase matches spec header style). Loading artifacts and a11y summary span removed from saved output.

**Performance:** Preconnect hint for browser logo domain. `will-change: opacity` for compositor promotion.