### PR TITLE
fix(core/xref-headings): prefix cross-spec section links with §

### DIFF
--- a/src/core/xref-headings.js
+++ b/src/core/xref-headings.js
@@ -76,7 +76,6 @@ export async function run(conf) {
   headingElems.forEach(({ elem, key }) => {
     const heading = headingTexts.get(key);
     if (heading?.title) {
-      elem.textContent = "";
       setHeadingContent(elem, heading);
     }
   });
@@ -152,14 +151,20 @@ export async function fetchHeadingTexts(queries, apiUrl = HEADINGS_API_URL) {
 
 /**
  * Sets heading content on an element using proper secno markup.
- * When a section number is available, produces `<bdi class="secno">N </bdi>Title`.
+ * Prefixes the reference with the "§" section sign (followed by a
+ * non-breaking space), matching in-document section links produced by
+ * core/anchor-expander. When a section number is available, produces
+ * `§\u00A0<bdi class="secno">N </bdi>Title`.
  * @param {HTMLElement} elem
  * @param {HeadingInfo} heading
  */
 export function setHeadingContent(elem, { title, number }) {
+  elem.classList.add("sec-ref");
+  elem.textContent = "";
+  elem.append("§\u00A0");
   if (number) {
     elem.append(html`<bdi class="secno">${number} </bdi>`, title);
   } else {
-    elem.textContent = title;
+    elem.append(title);
   }
 }

--- a/tests/data/headings.json
+++ b/tests/data/headings.json
@@ -11,6 +11,12 @@
       "id": "data-fetch",
       "title": "Fetching data",
       "number": "4.1"
+    },
+    {
+      "spec": "fetch",
+      "id": "acknowledgments",
+      "title": "Acknowledgments",
+      "number": null
     }
   ]
 }

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -401,7 +401,7 @@ describe("Core - Inlines", () => {
     expect(anchor).toBeTruthy();
     expect(anchor.href).toBe("https://fetch.spec.whatwg.org/#data-fetch");
     // Local fixture returns { number: "4.1", title: "Fetching data" }
-    expect(anchor.textContent).toBe("4.1 Fetching data");
+    expect(anchor.textContent).toBe("§ 4.1 Fetching data");
   });
 
   it("uses heading text from API for [[[SPEC#id]]] when available", async () => {
@@ -428,7 +428,7 @@ describe("Core - Inlines", () => {
     const secno1 = anchor.querySelector("bdi.secno");
     expect(secno1).toBeTruthy();
     expect(secno1.textContent).toBe("4 ");
-    expect(anchor.textContent).toBe("4 Fetching");
+    expect(anchor.textContent).toBe("§ 4 Fetching");
   });
 
   it("uses xref.headingApiUrl to fetch heading texts for [[[SPEC#id]]]", async () => {
@@ -454,7 +454,59 @@ describe("Core - Inlines", () => {
     const secno2 = anchor.querySelector("bdi.secno");
     expect(secno2).toBeTruthy();
     expect(secno2.textContent).toBe("4 ");
-    expect(anchor.textContent).toBe("4 Fetching");
+    expect(anchor.textContent).toBe("§ 4 Fetching");
+  });
+
+  it("prefixes [[[SPEC#id]]] with § even when the section has no number", async () => {
+    const config = {
+      xref: { headingApiUrl: `${location.origin}/tests/data/headings.json` },
+      localBiblio: {
+        fetch: {
+          title: "Fetch Standard",
+          href: "https://fetch.spec.whatwg.org/",
+        },
+      },
+    };
+    const body = `
+      <section id="test">
+        <p id="output">[[[fetch#acknowledgments]]]</p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(config, body));
+    const anchor = doc.querySelector("#output a[href]");
+    expect(anchor).toBeTruthy();
+    expect(anchor.href).toBe("https://fetch.spec.whatwg.org/#acknowledgments");
+    // Local fixture returns { number: null, title: "Acknowledgments" }
+    expect(anchor.classList).toContain("sec-ref");
+    expect(anchor.querySelector("bdi.secno")).toBeNull();
+    expect(anchor.textContent).toBe("§ Acknowledgments");
+  });
+
+  it("does not prefix [[[SPEC#id]]] with § when the headings API fails", async () => {
+    const config = {
+      xref: {
+        headingApiUrl: `${location.origin}/tests/data/does-not-exist-404.json`,
+      },
+      localBiblio: {
+        fetch: {
+          title: "Fetch Standard",
+          href: "https://fetch.spec.whatwg.org/",
+        },
+      },
+    };
+    const body = `
+      <section id="test">
+        <p id="output">[[[fetch#data-fetch]]]</p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(config, body));
+    const anchor = doc.querySelector("#output a[href]");
+    expect(anchor).toBeTruthy();
+    expect(anchor.href).toBe("https://fetch.spec.whatwg.org/#data-fetch");
+    // API failed → falls back to the spec title set by core/data-cite, with no "§".
+    expect(anchor.textContent).toBe("Fetch Standard");
+    // Fallback is the spec link, not a section reference — no sec-ref class.
+    expect(anchor.classList).not.toContain("sec-ref");
   });
 
   it("prefers alias text over heading text for [[[SPEC#id|text]]]", async () => {
@@ -500,7 +552,7 @@ describe("Core - Inlines", () => {
     const anchor = doc.querySelector("#output a[href]");
     expect(anchor).toBeTruthy();
     expect(anchor.href).toBe("https://fetch.spec.whatwg.org/#data-fetch");
-    expect(anchor.textContent).toBe("4.1 Fetching data");
+    expect(anchor.textContent).toBe("§ 4.1 Fetching data");
     // But it must NOT appear in the dfn-index "Terms defined by reference" table
     const externalTerms = doc.querySelectorAll(
       "#index-defined-elsewhere li[data-spec]"
@@ -533,7 +585,7 @@ describe("Core - Inlines", () => {
     const noAliasAnchor = doc.querySelector("#no-alias a[href]");
     expect(noAliasAnchor).toBeTruthy();
     // heading from local fixture: { number: "4.1", title: "Fetching data" }
-    expect(noAliasAnchor.textContent).toBe("4.1 Fetching data");
+    expect(noAliasAnchor.textContent).toBe("§ 4.1 Fetching data");
   });
 
   it("supports alias text with [[[SPEC|text]]] syntax (no fragment)", async () => {


### PR DESCRIPTION
Closes #5341

Cross-spec section references written as `[[[SPEC#id]]]` now render with a leading "§" section sign (for example, `[[[fetch#fetching]]]` becomes "§ 4 Fetching"), so they match in-document section references written as `[[[#id]]]`, which already render with the "§" via `core/anchor-expander`. The cross-spec links also now carry the `sec-ref` class for the same reason, keeping the two forms consistent in both text content and styling hooks.

The section sign is rendered the same way as the in-document path: a "§" followed by a non-breaking space (so the sign never wraps away from the number), then the `secno` and the title. When the referenced section has no number, the link renders as "§ Title". The API-failure fallback (which shows the spec title only) and author-supplied alias text (`[[[SPEC#id|text]]]`) are intentionally left unchanged — neither is a section reference, so neither gets the "§".
