### PR TITLE
feat(core/inlines): render inline code in [[[…|alias]]] link text

### DIFF
--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -19,6 +19,7 @@ import {
   showWarning,
   wrapInner,
 } from "./utils.js";
+import { setInlineContent } from "./inlines.js";
 import { sub } from "./pubsubhub.js";
 export const name = "core/data-cite";
 
@@ -210,7 +211,7 @@ export async function run() {
         elem.dataset.lt !== "the-empty-string" &&
         elem.textContent === ""
       ) {
-        elem.textContent = elem.dataset.lt;
+        setInlineContent(elem, elem.dataset.lt);
         delete elem.dataset.lt;
       }
 

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -199,7 +199,7 @@ function inlineRefMatches(matched) {
   if (refWithoutPrefix.startsWith("#")) {
     return linkText
       ? html`<a href="${refWithoutPrefix}" data-matched-text="${matched}"
-          >${linkText}</a
+          >${processInlineContent(linkText)}</a
         >`
       : html`<a href="${refWithoutPrefix}" data-matched-text="${matched}"></a>`;
   }
@@ -349,6 +349,19 @@ function processInlineContent(text) {
     });
   }
   return document.createTextNode(text);
+}
+
+/**
+ * Replaces an element's content with `text`, rendering inline `code` spans
+ * the same way `[= =]` and other inline syntaxes do. Used to apply the alias
+ * of a `[[[…|alias]]]` autolink as its display text.
+ * @param {HTMLElement} elem
+ * @param {string} text
+ */
+export function setInlineContent(elem, text) {
+  elem.textContent = "";
+  const content = processInlineContent(text);
+  elem.append(...(Array.isArray(content) ? content : [content]));
 }
 
 /**

--- a/src/core/xref-headings.js
+++ b/src/core/xref-headings.js
@@ -14,6 +14,7 @@
  */
 import { cacheHeadingsData, resolveHeadingsCache } from "./xref-headings-db.js";
 import { html } from "./import-maps.js";
+import { setInlineContent } from "./inlines.js";
 import { showWarning } from "./utils.js";
 
 export const name = "core/xref-headings";
@@ -53,7 +54,7 @@ export async function run(conf) {
 
   elems.forEach(elem => {
     if (elem.dataset.lt) {
-      elem.textContent = elem.dataset.lt;
+      setInlineContent(elem, elem.dataset.lt);
       delete elem.dataset.lt;
     } else {
       const spec = (elem.dataset.cite ?? "").replace(/^[!?]/, "");

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -631,6 +631,90 @@ describe("Core - Inlines", () => {
     expect(anchor.textContent).toBe("see this section");
   });
 
+  it("processes backticks in [[[#id|`code`]]] alias text", async () => {
+    const body = `
+      <section id="my-section">
+        <h2>My Section Heading</h2>
+      </section>
+      <section>
+        <h2>References</h2>
+        <p id="output">[[[#my-section|the \`display\` property]]]</p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(null, body));
+    const anchor = doc.querySelector("#output a[href='#my-section']");
+    expect(anchor).toBeTruthy();
+    expect(anchor.querySelector("code").textContent).toBe("display");
+    expect(anchor.textContent).toBe("the display property");
+  });
+
+  it("processes backticks amid surrounding, multi-line text in [[[#id|…]]]", async () => {
+    const body = `
+      <section id="my-section">
+        <h2>My Section Heading</h2>
+      </section>
+      <section>
+        <h2>References</h2>
+        <p id="output">[[[#my-section|foo
+          \`code\` bar
+        ]]]</p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(null, body));
+    const anchor = doc.querySelector("#output a[href='#my-section']");
+    expect(anchor).toBeTruthy();
+    const codes = anchor.querySelectorAll("code");
+    expect(codes).toHaveSize(1);
+    expect(codes[0].textContent).toBe("code");
+    expect(anchor.textContent).toContain("foo");
+    expect(anchor.textContent).toContain("bar");
+  });
+
+  it("processes backticks in [[[SPEC#id|`code`]]] alias text", async () => {
+    const config = {
+      xref: { headingApiUrl: `${location.origin}/tests/data/headings.json` },
+      localBiblio: {
+        fetch: {
+          title: "Fetch Standard",
+          href: "https://fetch.spec.whatwg.org/",
+        },
+      },
+    };
+    const body = `
+      <section id="test">
+        <p id="output">[[[fetch#data-fetch|the \`fetch\` method]]]</p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(config, body));
+    const anchor = doc.querySelector("#output a[href]");
+    expect(anchor).toBeTruthy();
+    expect(anchor.href).toBe("https://fetch.spec.whatwg.org/#data-fetch");
+    expect(anchor.querySelector("code").textContent).toBe("fetch");
+    expect(anchor.textContent).toBe("the fetch method");
+  });
+
+  it("processes backticks in [[[SPEC|`code`]]] alias text", async () => {
+    const config = {
+      localBiblio: {
+        fetch: {
+          title: "Fetch Standard",
+          href: "https://fetch.spec.whatwg.org/",
+        },
+      },
+    };
+    const body = `
+      <section id="test">
+        <p id="output">[[[fetch|the \`fetch\` spec]]]</p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(config, body));
+    const anchor = doc.querySelector("#output a[href]");
+    expect(anchor).toBeTruthy();
+    expect(anchor.href).toBe("https://fetch.spec.whatwg.org/");
+    expect(anchor.querySelector("code").textContent).toBe("fetch");
+    expect(anchor.textContent).toBe("the fetch spec");
+  });
+
   it("allows [[[#...]]] to be a general expander for ids in document", async () => {
     /** @param {string} text */
     function generateDataIncludeUrl(text) {


### PR DESCRIPTION
Closes #5343

Author aliases in the `[[[…|alias]]]` autolink now support inline code, so backticks in the alias render as a `<code>` element instead of appearing literally, matching how the `[= =]` inline-link syntax already does it. A shared `setInlineContent` helper applies the processed alias at the three sites that emit alias display text (same-document, cross-spec section, and cross-spec spec links).