### PR TITLE
chore: sync lockfile settings so frozen installs work

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 overrides:


### PR DESCRIPTION
`pnpm i --frozen-lockfile` currently fails on main with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, because the lockfile records `settings.autoInstallPeers: false` while the effective pnpm setting is `true`. This syncs the recorded setting so frozen installs work again; no dependency is added, removed, or version-changed.
