### PR TITLE
fix(w3c/headers): drop stray brace from TAG finding prevVersion URL

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -431,7 +431,7 @@ export async function run(conf) {
       const pubDate = ISODate.format(conf.publishDate);
       conf.thisVersion = w3Url(`${latestPath}-${pubDate}`);
       const prevPubDate = ISODate.format(conf.previousPublishDate);
-      conf.prevVersion = w3Url(`${latestPath}-${prevPubDate}}`);
+      conf.prevVersion = w3Url(`${latestPath}-${prevPubDate}`);
     } else if (conf.isCGBG || conf.isBasic) {
       conf.prevVersion = conf.prevVersion || "";
     } else {

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1153,9 +1153,11 @@ describe("W3C — Headers", () => {
       const doc = await makeRSDoc(ops);
       const [dt] = contains(doc, "dt", "Previous version:");
       expect(dt.nextElementSibling.localName).toBe("dd");
-      expect(dt.nextElementSibling.textContent).toContain(
-        "https://www.w3.org/2001/tag/doc"
-      );
+      const anchor = dt.nextElementSibling.querySelector("a");
+      const expected = "https://www.w3.org/2001/tag/doc/Foo-1977-03-15";
+      expect(anchor.href).toBe(expected);
+      // The URL is the link text too, so a stray character is visible to readers.
+      expect(anchor.textContent.trim()).toBe(expected);
     });
   });
 


### PR DESCRIPTION
A stray `}` in the template literal meant TAG findings got a previous-version URL ending in a percent-encoded brace, `.../doc/Foo-1977-03-15%7D`. The existing test only asserted `toContain()` on the containing text, so it never saw the trailing character; it now asserts the anchor's full href.

Written with AI: this change was generated by Claude, and the regression test was proven to fail without the fix. Per AI_POLICY.md.

<!-- ai-proof:start -->
Proof: the same karma run fails in `reverted-fix` mode with `Expected 'https://www.w3.org/2001/tag/doc/Foo-1977-03-15%7D' to be 'https://www.w3.org/2001/tag/doc/Foo-1977-03-15'` and passes on `08ef3ab4` with `TOTAL: 1 SUCCESS`. Reverting only `src/w3c/headers.js` and keeping the test is what produces the before-state, because the test itself is new in this commit. This is a rendering change: the URL is the link's text, so a reader saw the trailing `%7D` in the "Previous version:" row. Verified by probing the rendered DOM in both states.
<!-- ai-proof:
{
 "mode": "reverted-fix",
 "base": "e827ef5f",
 "head": "08ef3ab4",
 "repro": "BROWSERS=ChromeHeadless npx karma start tests/spec/karma.conf.cjs --single-run --grep=\"takes previousPublishDate and previousMaturity into account\"",
 "before": "failed",
 "after": "passed",
 "visual": true,
 "blocker": "the regression test lands in this commit, so it does not exist on the base commit and base-sha mode cannot show the failure"
}
-->
<!-- ai-proof:end -->

