### PR TITLE
add integration test for (bug?) nested includes with relative hrefs

### DIFF
--- a/tests/spec/core/data-include-spec.js
+++ b/tests/spec/core/data-include-spec.js
@@ -133,6 +133,43 @@ describe("Core — Data Include", () => {
     ).toBeTrue();
   });
 
+  it("resolves a nested data-include's relative URL against the top-level document, not the including file's own URL", async () => {
+    // Fixtures live under tests/spec/core/nested-include/:
+    //   outer.html                     <- the document under test
+    //   foo/bar.html                   <- fetched via outer.html's data-include="foo/bar.html"
+    //   includes/data.json             <- resolving "includes/data.json" against outer.html
+    //   foo/includes/data.json         <- resolving "includes/data.json" against foo/bar.html
+    //
+    // foo/bar.html itself has data-include="includes/data.json". This test
+    // asserts which of the two data.json files actually gets fetched, i.e.
+    // whether nested includes resolve relative URLs against the document
+    // that started the include chain, or against the file that declared
+    // the nested data-include.
+    const nestedIncludeUrl = "/tests/spec/core/nested-include/outer.html";
+    const ops = {
+      config: makeBasicConfig(),
+      body: makeDefaultBody(),
+    };
+    const doc = await makeRSDoc(ops, nestedIncludeUrl);
+
+    const outerTarget = doc.querySelector("#nested-target");
+    expect(outerTarget).toBeTruthy();
+    expect(outerTarget.querySelector("p").textContent).toBe("bar content");
+
+    const innerTarget = doc.querySelector("#inner-target");
+    expect(innerTarget).toBeTruthy();
+    // Current behavior: the nested data-include is resolved relative to
+    // outer.html (the top-level document), *not* relative to foo/bar.html
+    // (the file that declared it) — even though foo/bar.html was itself
+    // fetched from a "foo/" subdirectory.
+    expect(innerTarget.textContent).toContain(
+      "top-level document (outer.html)"
+    );
+    expect(innerTarget.textContent).not.toContain(
+      "included file's own directory"
+    );
+  });
+
   it("includes text when data-include-format is 'text'", async () => {
     const ops = {
       config: makeBasicConfig(),

--- a/tests/spec/core/nested-include/foo/bar.html
+++ b/tests/spec/core/nested-include/foo/bar.html
@@ -1,0 +1,15 @@
+<p>bar content</p>
+<!--
+  This nested include uses a URL relative to "includes/data.json". The
+  question this fixture answers: is that URL resolved relative to *this*
+  file's location (tests/spec/core/nested-include/foo/bar.html), which
+  would yield tests/spec/core/nested-include/foo/includes/data.json, or
+  relative to the top-level document that started the include chain
+  (tests/spec/core/nested-include/outer.html), which would yield
+  tests/spec/core/nested-include/includes/data.json?
+-->
+<div
+  id="inner-target"
+  data-include="includes/data.json"
+  data-include-format="text"
+></div>

--- a/tests/spec/core/nested-include/foo/includes/data.json
+++ b/tests/spec/core/nested-include/foo/includes/data.json
@@ -1,0 +1,1 @@
+{ "resolvedRelativeTo": "included file's own directory (foo/bar.html)" }

--- a/tests/spec/core/nested-include/includes/data.json
+++ b/tests/spec/core/nested-include/includes/data.json
@@ -1,0 +1,1 @@
+{ "resolvedRelativeTo": "top-level document (outer.html)" }

--- a/tests/spec/core/nested-include/outer.html
+++ b/tests/spec/core/nested-include/outer.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="utf-8" />
+    <title>Nested Include Outer Spec</title>
+    <script class="remove">
+      var respecConfig = {
+        specStatus: "ED",
+        shortName: "nested-include-outer",
+      };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+      <p>Basic doc</p>
+    </section>
+    <section id="sotd">
+      <p>CUSTOM PARAGRAPH</p>
+    </section>
+    <section id="nested-includes">
+      <!--
+        This outer include is relative to this document's own URL
+        (tests/spec/core/nested-include/outer.html), so it resolves to
+        tests/spec/core/nested-include/foo/bar.html
+      -->
+      <div id="nested-target" data-include="foo/bar.html"></div>
+    </section>
+  </body>
+</html>

--- a/tests/spec/karma.conf.cjs
+++ b/tests/spec/karma.conf.cjs
@@ -10,7 +10,7 @@ const additionalFiles = [
     included: false,
   },
   {
-    pattern: "tests/spec/**/*-spec.js",
+    pattern: process.env.SPEC_FILE_PATTERN || "tests/spec/**/*-spec.js",
     type: "module",
     included: false,
   },


### PR DESCRIPTION
Motivation:
* add a test asserting behavior of how nested `data-include` relative hyperlink references are resolved by respec into the actually-fetched URL

Background:
* I used `data-include="includes/section.md"` to include a file that itself had `data-include="example.json"`, thinking this would lead to `includes/example.json` included in my respec document. I was surprised to find my document rendering a 404 error instead, because respec fetched `example.json` not `includes/example.json`.
* [respec docs for data-include](https://respec.org/docs/#data-include) say "Paths are relative to the including document", but this isn't clear for document A that includes a document B that includes a document C. When document B includes document C, is 'the including document' doc B or A?
  * Currently the behavior is untested, but things behave like 'the including document' always means the outer-most including document. The current behavior seems like it may have been a bug/oversight.
  * It seems like `data-include` docs may have been written with the behavior I suspected in mind (paths in nested includes should be resolved relative to the document that includes them, not the top-most include), even if the current implementation behaves differently.
  * I strongly recommend behavior different than the status quo, because that way respec can include documents that themselves include via relative path. That will make it so a file (with nested includes) can be included in more than one respec document, and without having to know about the path of the file that includes it.
 
Questions
* [ ] Is the current behavior a bug or not?
  * If the current behavior is not matching what the docs intended by "Paths are relative to the including document", then I should update this PR so the test asserts not the current behavior, but the intended behavior. If that's appropriate, say so, and I will update the test and make it pass, so that it works like I wanted, and we can consider it a bug fix in the changeling.

Changes
* Adds an integration test for nested `data-include` includes where the included hrefs are relative URIs. Previously, the only test for nested includes used data URIs, which means there is no test asserting behavior of how nested includes build absolute URLs from the relative hrefs.
* Testers can set SPEC_FILE_PATTERN to override the default pattern used by integration tests. This can be used to speed up test runs by only scanning a subset of test file patterns, e.g. `SPEC_FILE_PATTERN='tests/spec/core/data-include-spec.js' pnpm test:integration`
