### PR TITLE
fix(tools): await puppeteer executablePath in release preflight

### DIFF
--- a/tools/release.cjs
+++ b/tools/release.cjs
@@ -354,7 +354,7 @@ async function preflight() {
       "node",
       [
         "-e",
-        'import("puppeteer").then(p => process.stdout.write(p.executablePath()))',
+        'import("puppeteer").then(async p => process.stdout.write(await p.executablePath()))',
       ],
       { timeout: 15000, showOutput: false }
     );


### PR DESCRIPTION
The release preflight writes the result of `puppeteer.executablePath()` straight to stdout, but puppeteer 25.0.0 made that method return a Promise (puppeteer/puppeteer#14965), so the write throws `ERR_INVALID_ARG_TYPE`, the bare `catch` swallows it, and the check reports "Puppeteer Chrome not found (required by respec2html)" even when Chrome is installed and resolvable. Awaiting the call fixes the false negative and stays compatible with the old synchronous signature, since awaiting a string is a no-op.