### PR TITLE
fix: unify noToc/noTOC config to canonical noTOC

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/setup-node@v7
         with: { node-version-file: '.nvmrc', cache: pnpm }
       - run: pnpm i --frozen-lockfile
-      - run: pnpm build:w3c & pnpm build:geonovum
+      - run: pnpm build:w3c && pnpm build:geonovum && pnpm build:aom && pnpm build:dini
       - run: pnpm test:unit
         env:
           BROWSERS: ${{ matrix.browser }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-node@v7
         with: { node-version-file: '.nvmrc', cache: pnpm }
       - run: pnpm i --frozen-lockfile
-      - run: pnpm build:w3c & pnpm build:geonovum
+      - run: pnpm build:w3c && pnpm build:geonovum && pnpm build:aom && pnpm build:dini
       - run: pnpm test
         env:
           BROWSERS: ChromeHeadless

--- a/src/aom/defaults.js
+++ b/src/aom/defaults.js
@@ -3,7 +3,7 @@
  * Sets the defaults for AOM specs
  */
 export const name = "aom/defaults";
-import { coreDefaults } from "../core/defaults.js";
+import { coreDefaults, normalizeNoTOC } from "../core/defaults.js";
 
 const licenses = new Map([
   [
@@ -64,6 +64,7 @@ export function run(conf) {
     lint,
   });
 
+  normalizeNoTOC(conf);
   // computed properties
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/aom/style.js
+++ b/src/aom/style.js
@@ -132,7 +132,7 @@ export function run(conf) {
   }
 
   // Attach W3C fixup script after we are done.
-  if (!conf.noToc) {
+  if (!conf.noTOC) {
     sub(
       "end-all",
       () => {

--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -2,6 +2,8 @@
 /**
  * Sets the core defaults
  */
+import { docLink, showWarning } from "./utils.js";
+
 export const name = "core/defaults";
 
 export const coreDefaults = {
@@ -21,3 +23,15 @@ export const coreDefaults = {
   highlightVars: true,
   addSectionLinks: true,
 };
+
+/**
+ * Aliases the deprecated `noToc` option to the canonical `noTOC`.
+ * @param {Conf} conf
+ */
+export function normalizeNoTOC(conf) {
+  if (!conf.hasOwnProperty("noToc")) return;
+  conf.noTOC ??= conf.noToc;
+  const msg = "The `noToc` configuration option is deprecated.";
+  const hint = docLink`Please use ${"[noTOC]"} instead.`;
+  showWarning(msg, name, { hint });
+}

--- a/src/dini/defaults.js
+++ b/src/dini/defaults.js
@@ -3,7 +3,7 @@
  * Sets the defaults for DINI specs
  */
 export const name = "dini/defaults";
-import { coreDefaults } from "../core/defaults.js";
+import { coreDefaults, normalizeNoTOC } from "../core/defaults.js";
 
 const licenses = new Map([
   [
@@ -78,6 +78,7 @@ export function run(conf) {
     lint,
   });
 
+  normalizeNoTOC(conf);
   // computed properties
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/dini/style.js
+++ b/src/dini/style.js
@@ -132,7 +132,7 @@ export function run(conf) {
   }
 
   // Attach W3C fixup script after we are done.
-  if (!conf.noToc) {
+  if (!conf.noTOC) {
     sub(
       "end-all",
       () => {

--- a/src/geonovum/defaults.js
+++ b/src/geonovum/defaults.js
@@ -3,7 +3,7 @@
  * Sets the defaults for Geonovum documents
  */
 export const name = "geonovum/defaults";
-import { coreDefaults } from "../core/defaults.js";
+import { coreDefaults, normalizeNoTOC } from "../core/defaults.js";
 
 const licenses = new Map([
   [
@@ -82,6 +82,7 @@ export function run(conf) {
     ...conf,
     lint,
   });
+  normalizeNoTOC(conf);
   // computed properties
   Object.assign(conf, computeProps(/** @type {NormalizedConf} */ (conf)));
 }

--- a/src/geonovum/style.js
+++ b/src/geonovum/style.js
@@ -152,7 +152,7 @@ export function run(conf) {
       styleFile = "base.css";
   }
 
-  if (!conf.noToc) {
+  if (!conf.noTOC) {
     sub(
       "end-all",
       () => {

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -120,6 +120,7 @@ interface Conf {
   afterEnd?: ProcessFn;
   specStatus?: string;
   wgId?: string;
+  /** @deprecated Use `noTOC` instead */
   noToc?: boolean;
   noTOC?: boolean;
   /** Disables injecting ReSpec styles */

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -14,7 +14,7 @@ import {
   trStatus,
 } from "./headers.js";
 import { codedJoinOr, docLink, showError } from "../core/utils.js";
-import { coreDefaults } from "../core/defaults.js";
+import { coreDefaults, normalizeNoTOC } from "../core/defaults.js";
 
 const w3cLogo = {
   src: "https://www.w3.org/StyleSheets/TR/2021/logos/W3C",
@@ -75,6 +75,7 @@ export function run(conf) {
     lint,
   });
 
+  normalizeNoTOC(conf);
   if (conf.specStatus !== "unofficial" && !conf.hasOwnProperty("license")) {
     conf.license = "w3c-software-doc";
   }

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -105,7 +105,7 @@ function styleMover(linkURL) {
  */
 export function run(conf) {
   // Attach W3C fixup script after we are done.
-  if (!conf.noToc) {
+  if (!conf.noTOC) {
     sub("end-all", attachFixupScript, { once: true });
   }
 

--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -236,6 +236,15 @@ export function makeBasicConfig(profile = "w3c") {
         ],
         specStatus: "PD",
       };
+    case "dini":
+      return {
+        editors: [
+          {
+            name: "Person Name",
+          },
+        ],
+        specStatus: "base",
+      };
     default:
       throw new Error(`Unknown profile: ${profile}`);
   }
@@ -271,5 +280,13 @@ export function makeStandardAomOps(config = {}, body = makeDefaultBody()) {
     body,
     config: { ...makeBasicConfig("aom"), ...config },
     profile: "aom",
+  };
+}
+
+export function makeStandardDiniOps(config = {}, body = makeDefaultBody()) {
+  return {
+    body,
+    config: { ...makeBasicConfig("dini"), ...config },
+    profile: "dini",
   };
 }

--- a/tests/spec/aom/style-spec.js
+++ b/tests/spec/aom/style-spec.js
@@ -52,7 +52,15 @@ describe("AOM - Style", () => {
     expect(elem.content).toBe(expectedStr);
   });
 
-  it("doesn't include fixup.js when noToc is set", async () => {
+  it("doesn't include fixup.js when noTOC is set", async () => {
+    const ops = makeStandardAomOps({ noTOC: true });
+    const doc = await makeRSDoc(ops);
+    const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
+    const elem = doc.querySelector(query);
+    expect(elem).toBeNull();
+  });
+
+  it("doesn't include fixup.js when the deprecated noToc is set", async () => {
     const ops = makeStandardAomOps({ noToc: true });
     const doc = await makeRSDoc(ops);
     const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";

--- a/tests/spec/core/id-headers-spec.js
+++ b/tests/spec/core/id-headers-spec.js
@@ -58,7 +58,7 @@ describe("Core - ID headers", () => {
       ariaLabel = deepAppendix.getAttribute("aria-label");
       expect(ariaLabel).toBe("Permalink for Appendix A.1");
 
-      // marked as noToc
+      // inside a section marked .notoc
       const deepH4 = doc.querySelector("h4 + a.self-link");
       ariaLabel = deepH4.getAttribute("aria-label");
       expect(ariaLabel).toBe("Permalink for this Section");

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -5,7 +5,10 @@ import {
   makeDefaultBody,
   makeRSDoc,
   makeStandardOps,
+  warningFilters,
 } from "../SpecHelper.js";
+
+const warnings = warningFilters.filter("core/defaults");
 
 describe("Core - Structure", () => {
   const body = `
@@ -121,7 +124,7 @@ describe("Core - Structure", () => {
     expect(normativeRef1.textContent).toBe("[normative]");
   });
 
-  it("should not build a ToC with noTOC", async () => {
+  it("should not build a ToC with noTOC and not warn", async () => {
     // test with noTOC
     const ops = {
       config: makeBasicConfig(),
@@ -130,6 +133,26 @@ describe("Core - Structure", () => {
     ops.config.noTOC = true;
     const doc = await makeRSDoc(ops);
     expect(doc.getElementById("toc")).toBeNull();
+    expect(warnings(doc)).toHaveSize(0);
+  });
+
+  it("should not build a ToC with the deprecated noToc, but warns", async () => {
+    const ops = {
+      config: { ...makeBasicConfig(), noToc: true },
+      body: "<section><h2>Section</h2></section>",
+    };
+    const doc = await makeRSDoc(ops);
+    expect(doc.getElementById("toc")).toBeNull();
+    expect(warnings(doc)).toHaveSize(1);
+  });
+
+  it("should prefer noTOC over the deprecated noToc", async () => {
+    const ops = {
+      config: { ...makeBasicConfig(), noToc: true, noTOC: false },
+      body: "<section><h2>Section</h2></section>",
+    };
+    const doc = await makeRSDoc(ops);
+    expect(doc.getElementById("toc")).toBeTruthy();
   });
 
   it("should include introductory sections in ToC", async () => {

--- a/tests/spec/dini/style-spec.js
+++ b/tests/spec/dini/style-spec.js
@@ -1,0 +1,24 @@
+"use strict";
+
+import { flushIframes, makeRSDoc, makeStandardDiniOps } from "../SpecHelper.js";
+
+describe("DINI - Style", () => {
+  afterAll(flushIframes);
+
+  const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
+
+  it("includes 'fixup.js'", async () => {
+    const doc = await makeRSDoc(makeStandardDiniOps());
+    expect(doc.querySelector(query)).toBeTruthy();
+  });
+
+  it("doesn't include fixup.js when noTOC is set", async () => {
+    const doc = await makeRSDoc(makeStandardDiniOps({ noTOC: true }));
+    expect(doc.querySelector(query)).toBeNull();
+  });
+
+  it("doesn't include fixup.js when the deprecated noToc is set", async () => {
+    const doc = await makeRSDoc(makeStandardDiniOps({ noToc: true }));
+    expect(doc.querySelector(query)).toBeNull();
+  });
+});

--- a/tests/spec/geonovum/style-spec.js
+++ b/tests/spec/geonovum/style-spec.js
@@ -87,12 +87,16 @@ describe("Geonovum - Style", () => {
     );
   });
 
-  it("shouldn't include fixup.js when noToc is set", async () => {
-    const ops = makeStandardGeoOps();
-    const newProps = {
-      noToc: true,
-    };
-    Object.assign(ops.config, newProps);
+  it("shouldn't include fixup.js when noTOC is set", async () => {
+    const ops = { ...makeStandardGeoOps({ noTOC: true }), profile: "geonovum" };
+    const doc = await makeRSDoc(ops);
+    const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
+    const elem = doc.querySelector(query);
+    expect(elem).toBeNull();
+  });
+
+  it("shouldn't include fixup.js when the deprecated noToc is set", async () => {
+    const ops = { ...makeStandardGeoOps({ noToc: true }), profile: "geonovum" };
     const doc = await makeRSDoc(ops);
     const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
     const elem = doc.querySelector(query);

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -250,13 +250,9 @@ describe("W3C - Style", () => {
     expect(linkBase.nextElementSibling).toBe(linkDarkMode);
   });
 
-  it("shouldn't include fixup.js when noToc is set", async () => {
-    const ops = makeStandardOps();
-    const newProps = {
-      noToc: true,
-    };
-    Object.assign(ops.config, newProps);
-    const doc = await makeRSDoc(ops, "spec/core/simple.html");
+  it("shouldn't include fixup.js when noTOC is set", async () => {
+    const ops = makeStandardOps({ noTOC: true });
+    const doc = await makeRSDoc(ops);
     const query = "script[src^='https://www.w3.org/scripts/TR/2021/fixup.js']";
     const elem = doc.querySelector(query);
     expect(elem).toBeNull();


### PR DESCRIPTION
Closes #5258

The config property was split: style movers used `noToc` (lowercase c) while `structure.js` used `noTOC`, so a spec author setting one spelling did not affect the other. This unifies the w3c, aom, dini and geonovum profiles on the canonical `noTOC` and normalizes the legacy `noToc` in each profile's defaults for backwards compatibility, and CI now builds all four profiles so the aom and dini changes are actually exercised.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
