### PR TITLE
chore(deps): update puppeteer and vnu-jar

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "simple-git-hooks": "^2.13.1",
     "sniffy-mimetype": "^1.1.1",
     "typescript": "^7.0.2",
-    "vnu-jar": "^26.8.6",
+    "vnu-jar": "^26.8.15",
     "webidl2": "^24.5.0"
   },
   "scripts": {
@@ -92,7 +92,7 @@
     "colors": "1.4.0",
     "finalhandler": "^2.1.1",
     "marked": "^18.0.9",
-    "puppeteer": "^25.7.0",
+    "puppeteer": "^25.8.0",
     "sade": "^1.8.1",
     "serve-static": "^2.2.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^18.0.9
         version: 18.0.9
       puppeteer:
-        specifier: ^25.7.0
-        version: 25.7.0
+        specifier: ^25.8.0
+        version: 25.8.0
       sade:
         specifier: ^1.8.1
         version: 1.8.1
@@ -169,8 +169,8 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
       vnu-jar:
-        specifier: ^26.8.6
-        version: 26.8.6
+        specifier: ^26.8.15
+        version: 26.8.15
       webidl2:
         specifier: ^24.5.0
         version: 24.5.0
@@ -293,8 +293,8 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@puppeteer/browsers@3.2.0':
-    resolution: {integrity: sha512-LlBrE8oqGfU7b1Nk2d5Q1SbuPhZxTj0cJEMDPEws28OjNMELlflekmPPuf4FnK03x0ZRjKaYwJElUcKK4kyqJA==}
+  '@puppeteer/browsers@3.2.1':
+    resolution: {integrity: sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -1966,12 +1966,12 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  puppeteer-core@25.7.0:
-    resolution: {integrity: sha512-wgBBj7dU5ceGyoT2PCrJpkYOhxPY8mDOmcSKZP92Cj5GgqQ3kv/UxzawnOLxiYuupe4bDf/yiQm3bzs/1nI0rQ==}
+  puppeteer-core@25.8.0:
+    resolution: {integrity: sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==}
     engines: {node: '>=22.12.0'}
 
-  puppeteer@25.7.0:
-    resolution: {integrity: sha512-zLBIYuW66SGwY7JNqGmiqeKiM92CYOs6xPibSRBPIeYGIfM1nE/8VCE8G0fGot2EfXENC4PbhktxLrQ0EK5Thg==}
+  puppeteer@25.8.0:
+    resolution: {integrity: sha512-3gcUJ+Jfodb5zNa/lWLZukBUwYiRIwAc8WRICoqfi+ZYmNWqpsPFyanTU3Gw/lhgII9aotVbAmhT6/NKHWgyUA==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -2347,8 +2347,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vnu-jar@26.8.6:
-    resolution: {integrity: sha512-P7f2yd+4GObCYt8kCDe+ERdPZ7PlHE1GXp8wSqclQm/VBlxyic0ME6wPqeEq9G6ZlpkR/CdygVgRth4FvL/jMw==}
+  vnu-jar@26.8.15:
+    resolution: {integrity: sha512-H9bgKeFA4ACpCDEW4++LFF+Tk0CS/XdRVJxM5lJ5fq/Qky84i+l3wucxvvmNiwL+efWYCSSoHZraFgRKq5GyCA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2564,7 +2564,7 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@puppeteer/browsers@3.2.0':
+  '@puppeteer/browsers@3.2.1':
     dependencies:
       modern-tar: 0.8.4
       yargs: 18.1.0
@@ -4023,9 +4023,9 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@25.7.0:
+  puppeteer-core@25.8.0:
     dependencies:
-      '@puppeteer/browsers': 3.2.0
+      '@puppeteer/browsers': 3.2.1
       chromium-bidi: 17.0.2(devtools-protocol@0.0.1666840)
       devtools-protocol: 0.0.1666840
       typed-query-selector: 2.12.2
@@ -4037,13 +4037,13 @@ snapshots:
       - utf-8-validate
       - yauzl
 
-  puppeteer@25.7.0:
+  puppeteer@25.8.0:
     dependencies:
-      '@puppeteer/browsers': 3.2.0
+      '@puppeteer/browsers': 3.2.1
       chromium-bidi: 17.0.2(devtools-protocol@0.0.1666840)
       devtools-protocol: 0.0.1666840
       lilconfig: 3.1.3
-      puppeteer-core: 25.7.0
+      puppeteer-core: 25.8.0
       typed-query-selector: 2.12.2
     transitivePeerDependencies:
       - bufferutil
@@ -4503,7 +4503,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vnu-jar@26.8.6: {}
+  vnu-jar@26.8.15: {}
 
   void-elements@2.0.1: {}
 


### PR DESCRIPTION
Updates puppeteer 25.7.0 to 25.8.0 and vnu-jar 26.8.6 to 26.8.15, both routine; puppeteer 25.8.0 adds a message telling you how to recover a partial browser folder, which is relevant after a partial Chrome download broke a release preflight recently.

Jasmine 7 was in this branch and has been dropped. It breaks the karma unit suite in both Chrome and Firefox: karma-jasmine-html-reporter 2.2.0 assigns to `jasmineStarted` on its reporter during boot, and jasmine 7 blocks monkey patching, so every run ends with "Cannot assign to read only property". The reporter also declares `jasmine-core` as a peer with a `^4 || ^5 || ^6` range, so it resolves whatever the root declares rather than a pinned copy. It needs a karma-jasmine-html-reporter release that supports jasmine 7, and gets its own PR then.