### PR TITLE
chore(deps): bump fast-uri and socket.io-parser overrides past CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,13 +121,13 @@
       "vnu-jar"
     ],
     "overrides": {
-      "fast-uri": "^3.1.4",
+      "fast-uri": "^3.1.5",
       "flatted": ">=3.4.2",
       "follow-redirects": ">=1.16.0",
       "jasmine>glob": ">=10.5.0",
       "lodash": ">=4.18.0",
       "qs": ">=6.14.2",
-      "socket.io-parser": ">=4.2.6",
+      "socket.io-parser": ">=4.2.7",
       "tmp": ">=0.2.4",
       "ws": ">=8.17.1",
       "@rollup/pluginutils>picomatch": "^2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   flatted: '>=3.4.2'
   follow-redirects: '>=1.16.0'
   jasmine>glob: '>=10.5.0'
   lodash: '>=4.18.0'
   qs: '>=6.14.2'
-  socket.io-parser: '>=4.2.6'
+  socket.io-parser: '>=4.2.7'
   tmp: '>=0.2.4'
   ws: '>=8.17.1'
   '@rollup/pluginutils>picomatch': ^2.3.2
@@ -1363,8 +1363,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2147,8 +2147,8 @@ packages:
   socket.io-adapter@2.5.2:
     resolution: {integrity: sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.7.2:
@@ -2917,7 +2917,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3443,7 +3443,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -4280,7 +4280,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.0
       debug: 4.4.3
@@ -4295,7 +4295,7 @@ snapshots:
       debug: 4.3.7
       engine.io: 6.6.9
       socket.io-adapter: 2.5.2
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
Two open Dependabot alerts, both high severity at CVSS 7.5, and both caused by our own pnpm overrides rather than by a dependency being behind. The overrides pinned `fast-uri` to `^3.1.4` and `socket.io-parser` to `>=4.2.6`, each exactly one patch below the fixed release, so the floors were holding the tree on vulnerable versions. Raising them to `^3.1.5` and `>=4.2.7` resolves both.

CVE-2026-18446 is host confusion in fast-uri via a backslash authority introducer; CVE-2026-69185 is a zero-attachment memory exhaustion in socket.io-parser. Both are development-scope transitives, so no published artifact is affected. After the change the lockfile contains exactly one copy of each, at the patched version.