### PR TITLE
chore(tests): drop karma-jasmine-html-reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "karma-chrome-launcher": "^3.2.0",
     "karma-firefox-launcher": "^2.1.3",
     "karma-jasmine": "^5.1.0",
-    "karma-jasmine-html-reporter": "^2.2.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-safari-launcher": "^1.0.0",
     "lint-staged": "^17.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,8 +246,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@jasminejs/reporters@1.1.0':
-    resolution: {integrity: sha512-JIrlfaf9c6m0+GtBAgZdcFB6RIRbFBbXxZDZ0WOewq4cLIEcVKEe0RgI1FA77M39FNzeSMTAm+LK/kcQVIkfGQ==}
+  '@jasminejs/reporters@1.0.0':
+    resolution: {integrity: sha512-rM3GG4vx2H1Gp5kYCTr9aKlOEJFd43pzpiMAiy5b1+FUc2ub4e6bS6yCi/WQNDzAa5MVp9++dwcoEtcIfoEnhA==}
 
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -2516,7 +2516,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@jasminejs/reporters@1.1.0': {}
+  '@jasminejs/reporters@1.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
@@ -3541,7 +3541,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.6
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -3694,7 +3694,7 @@ snapshots:
 
   jasmine@6.3.0:
     dependencies:
-      '@jasminejs/reporters': 1.1.0
+      '@jasminejs/reporters': 1.0.0
       glob: 13.0.6
       jasmine-core: 6.3.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       karma-jasmine:
         specifier: ^5.1.0
         version: 5.1.0(karma@6.4.4)
-      karma-jasmine-html-reporter:
-        specifier: ^2.2.0
-        version: 2.2.0(jasmine-core@6.3.0)(karma-jasmine@5.1.0(karma@6.4.4))(karma@6.4.4)
       karma-mocha-reporter:
         specifier: ^2.2.5
         version: 2.2.5(karma@6.4.4)
@@ -249,8 +246,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@jasminejs/reporters@1.0.0':
-    resolution: {integrity: sha512-rM3GG4vx2H1Gp5kYCTr9aKlOEJFd43pzpiMAiy5b1+FUc2ub4e6bS6yCi/WQNDzAa5MVp9++dwcoEtcIfoEnhA==}
+  '@jasminejs/reporters@1.1.0':
+    resolution: {integrity: sha512-JIrlfaf9c6m0+GtBAgZdcFB6RIRbFBbXxZDZ0WOewq4cLIEcVKEe0RgI1FA77M39FNzeSMTAm+LK/kcQVIkfGQ==}
 
   '@jridgewell/gen-mapping@0.3.3':
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -1654,13 +1651,6 @@ packages:
   karma-firefox-launcher@2.1.3:
     resolution: {integrity: sha512-LMM2bseebLbYjODBOVt7TCPP9OI2vZIXCavIXhkO9m+10Uj5l7u/SKoeRmYx8FYHTVGZSpk6peX+3BMHC1WwNw==}
 
-  karma-jasmine-html-reporter@2.2.0:
-    resolution: {integrity: sha512-J0laEC43Oy2RdR5V5R3bqmdo7yRIYySq6XHKbA+e5iSAgLjhR1oICLGeSREPlJXpeyNcdJf3J17YcdhD0mRssQ==}
-    peerDependencies:
-      jasmine-core: ^4.0.0 || ^5.0.0 || ^6.0.0
-      karma: ^6.0.0
-      karma-jasmine: ^5.0.0
-
   karma-jasmine@5.1.0:
     resolution: {integrity: sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==}
     engines: {node: '>=12'}
@@ -2526,7 +2516,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@jasminejs/reporters@1.0.0': {}
+  '@jasminejs/reporters@1.1.0': {}
 
   '@jridgewell/gen-mapping@0.3.3':
     dependencies:
@@ -3551,7 +3541,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -3704,7 +3694,7 @@ snapshots:
 
   jasmine@6.3.0:
     dependencies:
-      '@jasminejs/reporters': 1.0.0
+      '@jasminejs/reporters': 1.1.0
       glob: 13.0.6
       jasmine-core: 6.3.0
 
@@ -3728,12 +3718,6 @@ snapshots:
     dependencies:
       is-wsl: 2.2.0
       which: 3.0.1
-
-  karma-jasmine-html-reporter@2.2.0(jasmine-core@6.3.0)(karma-jasmine@5.1.0(karma@6.4.4))(karma@6.4.4):
-    dependencies:
-      jasmine-core: 6.3.0
-      karma: 6.4.4
-      karma-jasmine: 5.1.0(karma@6.4.4)
 
   karma-jasmine@5.1.0(karma@6.4.4):
     dependencies:

--- a/tests/karma.conf.base.cjs
+++ b/tests/karma.conf.base.cjs
@@ -43,7 +43,6 @@ module.exports = config => {
     plugins: [
       require("karma-jasmine"),
       require("karma-mocha-reporter"),
-      require("karma-jasmine-html-reporter"),
       require("karma-chrome-launcher"),
       require("karma-firefox-launcher"),
       require("karma-safari-launcher"),
@@ -70,7 +69,7 @@ module.exports = config => {
     },
 
     preprocessors: {},
-    reporters: ["mocha", "kjhtml"],
+    reporters: ["mocha"],
     port: 9876,
     colors: true,
 


### PR DESCRIPTION
The only thing `kjhtml` provides is the interactive results view on the karma debug page, which nothing in the repo, CI, or the dev server depends on. It also blocks upgrading jasmine: it assigns to `jasmineStarted` during boot and jasmine 7 freezes that, so every run under jasmine 7 dies with "Cannot assign to read only property". There is no fixed release to wait for, since the latest is 2.2.0 and its peer range still stops at `jasmine-core ^6`.

Removing it is three deletions: the devDependency, the plugin require, and the reporter entry. Suites are unchanged at 56 unit and 1130 integration, and with the reporter gone a temporary jasmine 7 install passes cleanly instead of throwing, which is the point of the change.