### PR TITLE
refactor(tools): replace colors with util.styleText

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "test:integration": "karma start ./tests/spec/karma.conf.cjs --single-run"
   },
   "dependencies": {
-    "colors": "1.4.0",
     "finalhandler": "^2.1.1",
     "marked": "^18.0.9",
     "puppeteer": "^25.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
 
   .:
     dependencies:
-      colors:
-        specifier: 1.4.0
-        version: 1.4.0
       finalhandler:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1035,10 +1032,6 @@ packages:
 
   colors@1.0.3:
     resolution: {integrity: sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==}
-    engines: {node: '>=0.1.90'}
-
-  colors@1.4.0:
-    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
     engines: {node: '>=0.1.90'}
 
   commander@2.20.3:
@@ -3135,8 +3128,6 @@ snapshots:
   color-name@1.1.4: {}
 
   colors@1.0.3: {}
-
-  colors@1.4.0: {}
 
   commander@2.20.3: {}
 

--- a/tools/builder.cjs
+++ b/tools/builder.cjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 const sade = require("sade");
-const colors = require("colors");
+const { styleText } = require("node:util");
 const { readFileSync } = require("fs");
 const path = require("path");
 const rollup = require("rollup");
@@ -155,9 +155,9 @@ if (require.main === module) {
     .describe(
       "Builder builds a ReSpec profile. Profile must be in the profiles/ folder (e.g., w3c.js)"
     )
-    .example(`w3c ${colors.dim("# Build W3C profile.")}`)
+    .example(`w3c ${styleText("dim", "# Build W3C profile.")}`)
     .example(
-      `w3c --debug ${colors.dim("# Build W3C profile without optimizations.")}`
+      `w3c --debug ${styleText("dim", "# Build W3C profile without optimizations.")}`
     )
     .option("-d, --debug", "Disable optimization to ease debugging", false)
     .option("-w, --watch", "Automatically re-build on file changes", false)
@@ -169,7 +169,7 @@ if (require.main === module) {
       try {
         await Builder.build({ name: profile, debug: opts.debug });
       } catch (err) {
-        console.error(colors.red(err.stack));
+        console.error(styleText("red", err.stack));
         return process.exit(1);
       }
     })

--- a/tools/dev-server.cjs
+++ b/tools/dev-server.cjs
@@ -15,7 +15,7 @@ const { createServer } = require("http");
 const chokidar = require("chokidar");
 const karma = require("karma");
 const serve = require("serve-handler");
-const colors = require("colors");
+const { styleText } = require("node:util");
 const sade = require("sade");
 const serveConfig = require("../serve.json");
 const { Builder } = require("./builder.cjs");
@@ -155,14 +155,14 @@ async function run(args) {
       }
       await karmaServer.run();
     } catch (err) {
-      console.error(colors.red(err.stack));
+      console.error(styleText("red", err.stack));
     } finally {
       isActive = false;
     }
   }
 
   async function onError(err) {
-    console.error(colors.red(err.stack));
+    console.error(styleText("red", err.stack));
     await karmaServer.stop();
     process.exit(1);
   }
@@ -191,7 +191,10 @@ async function printWelcomeMessage(args) {
 
   const message = messages
     .map(([title, text]) => {
-      return colors.white.bold(`${title}:`.padEnd(30)) + colors.white(text);
+      return (
+        styleText(["white", "bold"], `${title}:`.padEnd(30)) +
+        styleText("white", text)
+      );
     })
     .join("\n");
 

--- a/tools/release.cjs
+++ b/tools/release.cjs
@@ -2,7 +2,7 @@
 // @ts-check
 const { Builder } = require("./builder.cjs");
 const cmdPrompt = require("prompt");
-const colors = require("colors");
+const { styleText } = require("node:util");
 const { execFile, spawn } = require("child_process");
 const loading = require("loading-indicator");
 const fs = require("fs");
@@ -47,7 +47,9 @@ function commandRunner(file, baseArgs = []) {
    */
   const runner = (cmd, options = { showOutput: false }) => {
     const args = [...baseArgs, ...cmd];
-    console.log(colors.cyan(`Run: ${file} ${colors.grey(args.join(" "))}`));
+    console.log(
+      styleText("cyan", `Run: ${file} ${styleText("grey", args.join(" "))}`)
+    );
     if (DEBUG) {
       return Promise.resolve("");
     }
@@ -79,9 +81,10 @@ const Prompts = {
    */
   async askSwitchToBranch(from, to) {
     const promptOps = {
-      description: `You're on branch ${colors.green(
+      description: `You're on branch ${styleText(
+        "green",
         from
-      )}. Switch to ${colors.green(to)}?`,
+      )}. Switch to ${styleText("green", to)}?`,
       pattern: /^[yn]$/i,
       message: "Values can be 'y' or 'n'.",
       default: "y",
@@ -112,7 +115,8 @@ const Prompts = {
     try {
       await this.askQuestion(promptOps);
     } catch (err) {
-      const warning = colors.yellow(
+      const warning = styleText(
+        "yellow",
         "🚨 Make sure to run `git checkout main` and reset any changes."
       );
       console.warn(warning);
@@ -155,7 +159,10 @@ const Prompts = {
               : "❓";
           // colorize
           if (match) {
-            result = result.replace(match.toLowerCase(), colors.green(match));
+            result = result.replace(
+              match.toLowerCase(),
+              styleText("green", match)
+            );
           }
           return `  ${icon} ${result}`;
         })
@@ -249,7 +256,8 @@ const Prompts = {
 
   async askPushAll() {
     const promptOps = {
-      description: `${colors.red(
+      description: `${styleText(
+        "red",
         "🔥  Ready to make this live? 🔥"
       )}  (last chance!)`,
       pattern: /^[yn]$/i,
@@ -329,7 +337,7 @@ class Indicator {
 }
 
 async function preflight() {
-  console.log(colors.cyan("\n  Preflight checks\n"));
+  console.log(styleText("cyan", "\n  Preflight checks\n"));
   const errors = [];
 
   // Java (needed for vnu HTML validator)
@@ -338,7 +346,7 @@ async function preflight() {
       timeout: 10000,
       showOutput: false,
     });
-    console.log(colors.green("  ✓ Java runtime"));
+    console.log(styleText("green", "  ✓ Java runtime"));
   } catch {
     errors.push(
       "Java runtime not found (required by vnu HTML validator).\n" +
@@ -361,7 +369,7 @@ async function preflight() {
     if (!fs.existsSync(chromePath.trim())) {
       throw new Error("Chrome binary missing");
     }
-    console.log(colors.green("  ✓ Puppeteer Chrome"));
+    console.log(styleText("green", "  ✓ Puppeteer Chrome"));
   } catch {
     errors.push(
       "Puppeteer Chrome not found (required by respec2html).\n" +
@@ -375,7 +383,7 @@ async function preflight() {
       timeout: 10000,
       showOutput: false,
     });
-    console.log(colors.green("  ✓ GitHub CLI (gh)"));
+    console.log(styleText("green", "  ✓ GitHub CLI (gh)"));
   } catch {
     errors.push(
       "GitHub CLI not found or not authenticated (required for creating releases).\n" +
@@ -407,23 +415,25 @@ async function preflight() {
           `"gh-pages" exists on ${remotes.length} remotes:\n${remotes.map(r => `      ${r.trim()}`).join("\n")}\n    Fix: git config checkout.defaultRemote origin`
         );
       } else {
-        console.log(colors.green("  ✓ gh-pages branch (via defaultRemote)"));
+        console.log(
+          styleText("green", "  ✓ gh-pages branch (via defaultRemote)")
+        );
       }
     } else {
-      console.log(colors.green("  ✓ gh-pages branch"));
+      console.log(styleText("green", "  ✓ gh-pages branch"));
     }
   } catch {
     errors.push("Could not verify gh-pages branch status.");
   }
 
   if (errors.length) {
-    console.log(colors.red("\n  ❌ Preflight failed:\n"));
+    console.log(styleText("red", "\n  ❌ Preflight failed:\n"));
     errors.forEach((err, i) => {
-      console.log(colors.red(`  ${i + 1}. ${err}\n`));
+      console.log(styleText("red", `  ${i + 1}. ${err}\n`));
     });
     throw new Error("Fix the issues above and try again.");
   }
-  console.log(colors.green("\n  ✅ All preflight checks passed.\n"));
+  console.log(styleText("green", "\n  ✅ All preflight checks passed.\n"));
 }
 
 /**
@@ -433,7 +443,9 @@ async function preflight() {
  * @returns {Promise<void>}
  */
 function toSpawnPromise(file, args) {
-  console.log(colors.cyan(`Run: ${file} ${colors.grey(args.join(" "))}`));
+  console.log(
+    styleText("cyan", `Run: ${file} ${styleText("grey", args.join(" "))}`)
+  );
   if (DEBUG) return Promise.resolve();
   return new Promise((resolve, reject) => {
     const proc = spawn(file, args, { stdio: "inherit" });
@@ -459,7 +471,7 @@ function toSpawnPromise(file, args) {
  * @param {string} initialBranch
  */
 async function rollback(version, mainHead, ghPagesHead, initialBranch) {
-  console.log(colors.yellow("\n  ⏪ Rolling back local changes...\n"));
+  console.log(styleText("yellow", "\n  ⏪ Rolling back local changes...\n"));
   try {
     const currentBranch = await getCurrentBranch();
     if (currentBranch !== "main") {
@@ -470,16 +482,18 @@ async function rollback(version, mainHead, ghPagesHead, initialBranch) {
   }
   try {
     await git(["tag", "-d", `v${version}`]);
-    console.log(colors.yellow(`  Deleted tag v${version}`));
+    console.log(styleText("yellow", `  Deleted tag v${version}`));
   } catch {
     // tag may not exist yet
   }
   if (mainHead) {
     try {
       await git(["reset", "--hard", mainHead]);
-      console.log(colors.yellow(`  Reset main to ${mainHead.slice(0, 8)}`));
+      console.log(
+        styleText("yellow", `  Reset main to ${mainHead.slice(0, 8)}`)
+      );
     } catch {
-      console.log(colors.red("  Failed to reset main — check manually."));
+      console.log(styleText("red", "  Failed to reset main — check manually."));
     }
   }
   if (ghPagesHead) {
@@ -487,10 +501,12 @@ async function rollback(version, mainHead, ghPagesHead, initialBranch) {
       await git(["switch", "gh-pages"]);
       await git(["reset", "--hard", ghPagesHead]);
       console.log(
-        colors.yellow(`  Reset gh-pages to ${ghPagesHead.slice(0, 8)}`)
+        styleText("yellow", `  Reset gh-pages to ${ghPagesHead.slice(0, 8)}`)
       );
     } catch {
-      console.log(colors.red("  Failed to reset gh-pages — check manually."));
+      console.log(
+        styleText("red", "  Failed to reset gh-pages — check manually.")
+      );
     } finally {
       await git(["switch", "main"]);
     }
@@ -508,11 +524,13 @@ async function rollback(version, mainHead, ghPagesHead, initialBranch) {
 const indicators = new Map([
   [
     "remote-update",
-    new Indicator(colors.green(" Performing Git remote update... 📡 ")),
+    new Indicator(styleText("green", " Performing Git remote update... 📡 ")),
   ],
   [
     "push-to-server",
-    new Indicator(colors.green(" Pushing everything back to server... 📡")),
+    new Indicator(
+      styleText("green", " Pushing everything back to server... 📡")
+    ),
   ],
 ]);
 
@@ -568,7 +586,9 @@ const run = async () => {
     for (const name of ["w3c", "geonovum", "dini", "aom"]) {
       await Builder.build({ name });
     }
-    console.log(colors.green(" Making sure the generated version is ok... 🕵🏻"));
+    console.log(
+      styleText("green", " Making sure the generated version is ok... 🕵🏻")
+    );
     const source = `file:///${__dirname}/../examples/basic.built.html`;
     const tempFile = path.join(os.tmpdir(), "index.html");
     await node(
@@ -579,9 +599,11 @@ const run = async () => {
     );
 
     // Do HTML validation
-    console.log(colors.green(" Making sure HTML validator is happy... 🕵🏻"));
+    console.log(
+      styleText("green", " Making sure HTML validator is happy... 🕵🏻")
+    );
     await validator(["--stdout", tempFile]);
-    console.log(colors.green(" Build Seems good... ✅"));
+    console.log(styleText("green", " Build Seems good... ✅"));
 
     // 4. Commit your changes
     await git(["add", "builds", "package.json", "pnpm-lock.yaml"]);
@@ -611,11 +633,11 @@ const run = async () => {
     indicators.get("push-to-server").hide();
 
     // 7. Publish to npm (interactive for OTP auth)
-    console.log(colors.green(" Publishing to npm... 📡"));
+    console.log(styleText("green", " Publishing to npm... 📡"));
     await toSpawnPromise("npm", ["publish"]);
 
     // 8. Create GitHub Release (triggers W3C CDN sync)
-    console.log(colors.green(" Creating GitHub Release... 📡"));
+    console.log(styleText("green", " Creating GitHub Release... 📡"));
     await toExecFilePromise(
       "gh",
       ["release", "create", `v${version}`, "--generate-notes"],
@@ -626,10 +648,11 @@ const run = async () => {
       await Prompts.askSwitchToBranch("main", initialBranch);
     }
   } catch (err) {
-    console.error(colors.red(`\n☠  ${err.stack}`));
+    console.error(styleText("red", `\n☠  ${err.stack}`));
     if (pushed) {
       console.log(
-        colors.yellow(
+        styleText(
+          "yellow",
           `\n  Git push succeeded but a later step failed.\n` +
             `  You may need to run manually:\n` +
             `    npm publish\n` +

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -1,32 +1,32 @@
 #!/usr/bin/env node
 import { readFile, writeFile } from "fs/promises";
-import colors from "colors";
 import finalhandler from "finalhandler";
 import http from "http";
 import { marked } from "marked";
 import path from "path";
 import sade from "sade";
 import serveStatic from "serve-static";
+import { styleText } from "node:util";
 import { toHTML } from "./respecDocWriter.js";
 
 const __dirname = import.meta.dirname;
 
 class Renderer extends marked.Renderer {
   strong(token) {
-    return colors.bold(this.parser.parseInline(token.tokens));
+    return styleText("bold", this.parser.parseInline(token.tokens));
   }
   em(token) {
-    return colors.italic(this.parser.parseInline(token.tokens));
+    return styleText("italic", this.parser.parseInline(token.tokens));
   }
   codespan(token) {
-    return colors.underline(unescape(token.text));
+    return styleText("underline", unescape(token.text));
   }
   paragraph(token) {
     return unescape(this.parser.parseInline(token.tokens));
   }
   link(token) {
     const text = this.parser.parseInline(token.tokens);
-    return `[${text}](${colors.blue.dim.underline(token.href)})`;
+    return `[${text}](${styleText(["blue", "dim", "underline"], token.href)})`;
   }
   list(token) {
     const body = token.items.map(item => this.listitem(item)).join("");
@@ -50,8 +50,8 @@ class Logger {
    */
   info(message, timeRemaining) {
     if (!this.verbose) return;
-    const header = colors.dim.bgWhite.black.bold("[INFO]");
-    const time = colors.dim(`[Timeout: ${timeRemaining}ms]`);
+    const header = styleText(["dim", "bgWhite", "black", "bold"], "[INFO]");
+    const time = styleText("dim", `[Timeout: ${timeRemaining}ms]`);
     console.error(header, time, message);
   }
 
@@ -60,8 +60,8 @@ class Logger {
    * @param {RsError} rsError
    */
   error(rsError) {
-    const header = colors.bgRed.white.bold("[ERROR]");
-    const message = colors.red(this._formatMarkdown(rsError.message));
+    const header = styleText(["bgRed", "white", "bold"], "[ERROR]");
+    const message = styleText("red", this._formatMarkdown(rsError.message));
     console.error(header, message);
     if (rsError.plugin) {
       this._printDetails(rsError);
@@ -70,8 +70,8 @@ class Logger {
 
   /** @param {RsError} rsError */
   warn(rsError) {
-    const header = colors.bgYellow.black.bold("[WARNING]");
-    const message = colors.yellow(this._formatMarkdown(rsError.message));
+    const header = styleText(["bgYellow", "black", "bold"], "[WARNING]");
+    const message = styleText("yellow", this._formatMarkdown(rsError.message));
     console.error(header, message);
     if (rsError.plugin) {
       this._printDetails(rsError);
@@ -80,14 +80,14 @@ class Logger {
 
   /** @param {Error | string} error */
   fatal(error) {
-    const header = colors.bgRed.white.bold("[FATAL]");
-    const message = colors.red(error.stack || error);
+    const header = styleText(["bgRed", "white", "bold"], "[FATAL]");
+    const message = styleText("red", error.stack || error);
     console.error(header, message);
     // Errors thrown by respecDocWriter keep the original in `cause`, so the
     // underlying stack is only reachable by walking the chain.
     let cause = error instanceof Error ? error.cause : undefined;
     for (let depth = 0; cause instanceof Error && depth < 5; depth++) {
-      console.error(colors.red(`Caused by: ${cause.stack}`));
+      console.error(styleText("red", `Caused by: ${cause.stack}`));
       cause = cause.cause;
     }
   }
@@ -105,7 +105,11 @@ class Logger {
       const longestTitle = shouldPrintStacktrace ? "Stacktrace" : "Plugin";
       const padWidth = longestTitle.length + 1;
       const paddedTitle = `${title}:`.padStart(padWidth);
-      console.error(" ", colors.bold(paddedTitle), this._formatMarkdown(value));
+      console.error(
+        " ",
+        styleText("bold", paddedTitle),
+        this._formatMarkdown(value)
+      );
     };
     print("Count", rsError.elements && String(rsError.elements.length));
     print("Plugin", rsError.plugin);
@@ -113,7 +117,7 @@ class Logger {
     if (shouldPrintStacktrace) {
       let stacktrace = `${rsError.stack}`;
       if (rsError.cause) {
-        stacktrace += `\n    ${colors.bold("Caused by:")} ${rsError.cause.stack.split("\n").join("\n   ")}`;
+        stacktrace += `\n    ${styleText("bold", "Caused by:")} ${rsError.cause.stack.split("\n").join("\n   ")}`;
       }
       print("Stacktrace", stacktrace);
     }
@@ -173,18 +177,20 @@ class StaticServer {
 
 const cli = sade("respec [source] [destination]", true)
   .describe("Converts a ReSpec source file to HTML and writes to destination.")
-  .example(`input.html output.html ${colors.dim("# Output to a file.")}`)
+  .example(`input.html output.html ${styleText("dim", "# Output to a file.")}`)
   .example(
-    `http://example.com/spec.html stdout ${colors.dim("# Output to stdout.")}`
+    `http://example.com/spec.html stdout ${styleText("dim", "# Output to stdout.")}`
   )
   .example(
-    `http://example.com/spec.html output.html -e -w ${colors.dim(
+    `http://example.com/spec.html output.html -e -w ${styleText(
+      "dim",
       "# Halt on errors or warning."
     )}`
   )
   .example("--src http://example.com/spec.html --out spec.html")
   .example(
-    `--localhost index.html out.html ${colors.dim(
+    `--localhost index.html out.html ${styleText(
+      "dim",
       "# Generate file using a local web server."
     )}`
   );


### PR DESCRIPTION
Node has `util.styleText` built in and `engines.node` is already `>=24`, so the `colors` dependency was doing nothing a stdlib call could not. It was also in `dependencies` rather than `devDependencies`, and `tools/respec2html.js` is a published file, so every consumer was installing it.

All thirteen formats in use are supported, and the chained forms translate to the array form with byte-identical output (`colors.bgRed.white.bold(x)` becomes `styleText(["bgRed", "white", "bold"], x)`). One four-part chain differs only in a reset code emitted after the visible text, so rendering is unchanged.

One deliberate behavior change: `colors` emitted escape codes even when piped, while `styleText` omits them for non-TTY streams. Redirected tool output is now plain text, and terminals still get color, including the interactive release prompts.

Verified by running the tools rather than only linting: `respec2html --help`, its fatal-error path, a real document conversion with `--verbose`, `builder.cjs w3c`, and the release preflight, which is the heaviest file at 31 call sites and still prints its green checkmarks.