### PR TITLE
refactor(core/xref): drop dead-code version-check URL guard, pin construction invariant

### DIFF
--- a/src/core/xref-db.js
+++ b/src/core/xref-db.js
@@ -71,6 +71,10 @@ async function shouldBustCache() {
   }
 
   const url = new URL("meta/version", API_URL).href;
+  const parsedUrl = new URL(url);
+  if (parsedUrl.protocol !== "https:" || parsedUrl.hostname !== "respec.org") {
+    return false;
+  }
   const res = await fetch(url);
   if (!res.ok) return false;
   const lastUpdated = await res.text();

--- a/src/core/xref-db.js
+++ b/src/core/xref-db.js
@@ -71,10 +71,6 @@ async function shouldBustCache() {
   }
 
   const url = new URL("meta/version", API_URL).href;
-  const parsedUrl = new URL(url);
-  if (parsedUrl.protocol !== "https:" || parsedUrl.hostname !== "respec.org") {
-    return false;
-  }
   const res = await fetch(url);
   if (!res.ok) return false;
   const lastUpdated = await res.text();

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -12,6 +12,7 @@ import {
   makeRSDoc,
   makeStandardOps,
 } from "../SpecHelper.js";
+import { API_URL } from "../../../src/core/xref.js";
 
 describe("Core — xref", () => {
   afterAll(flushIframes);
@@ -1090,6 +1091,21 @@ describe("Core — xref", () => {
       expect(doc.body.dataset.cite.split(" ")).toEqual(
         jasmine.arrayWithExactContents(["XHR", "SVG"])
       );
+    });
+  });
+
+  describe("API_URL construction", () => {
+    it("uses the canonical respec.org xref endpoint as API_URL", () => {
+      expect(API_URL).toBe("https://respec.org/xref/");
+    });
+
+    it("resolves the version-check URL against the fixed API_URL origin", () => {
+      // The version-check request is derived from the hardcoded API_URL and is
+      // not author-configurable, so it always targets respec.org.
+      const versionURL = new URL("meta/version", API_URL);
+      expect(versionURL.href).toBe("https://respec.org/xref/meta/version");
+      expect(versionURL.protocol).toBe("https:");
+      expect(versionURL.hostname).toBe("respec.org");
     });
   });
 


### PR DESCRIPTION
## Summary

Clarifies the xref version-check URL construction and adds a regression test.

## Background

This PR originally landed as a security fix (scanner rule `V-002`, flagged as an SSRF at `src/core/xref-db.js:72`). After review — thanks @marcoscaceres — that classification is a **false positive**:

- The version-check URL is built from a **hardcoded constant**: `new URL("meta/version", API_URL)` where `API_URL = "https://respec.org/xref/"` (`src/core/xref.js`). `API_URL` is never reassigned or overridden, so the URL is `https://respec.org/...` **by construction** — it cannot be attacker-influenced.
- There is no `respecConfig` path that changes `API_URL` or the `meta/version` request. The original "if API_URL can be overridden via respecConfig" premise doesn't hold.
- The only author-configurable URL is `conf.xref.url`, which feeds a **different** request (the xref search `POST`) and is an intended, documented, already-tested feature (authors may point xref at their own endpoint). Restricting it would break supported behavior.
- The AWS-metadata scenario doesn't apply: this is a browser-side `fetch()`, not a server-side request.

## Changes

- **Revert** the protocol/hostname guard added to `src/core/xref-db.js` — it was unreachable dead code and needlessly coupled the module to the literal host `respec.org`.
- **Add a regression test** (`tests/spec/core/xref-spec.js`) pinning the real invariant: `API_URL` and the derived `meta/version` URL always resolve to the `https://respec.org` origin.

No security framing and no new URL allowlist. This is a small robustness/documentation change.
