### PR TITLE
fix(core/biblio-db): await transaction commit before resolving

### DIFF
--- a/src/core/biblio-db.js
+++ b/src/core/biblio-db.js
@@ -50,17 +50,18 @@ async function openIdb() {
   // Clean the database of expired biblio entries.
   const now = Date.now();
   for (const storeName of [...ALLOWED_TYPES]) {
-    const store = db.transaction(storeName, "readwrite").store;
+    const tx = db.transaction(storeName, "readwrite");
     const range = IDBKeyRange.lowerBound(now);
-    let result = await store.openCursor(range);
+    let result = await tx.store.openCursor(range);
     while (result?.value) {
       /** @type {StoredBiblioEntry} */
       const entry = result.value;
       if (entry.expires === undefined || entry.expires < now) {
-        await store.delete(entry.id);
+        await tx.store.delete(entry.id);
       }
       result = await result.continue();
     }
+    await tx.done;
   }
 
   return db;
@@ -199,13 +200,20 @@ export const biblioDB = {
     if (isInDB) {
       const entry = await this.get(type, details.id);
       if (entry && entry.expires !== undefined && entry.expires < Date.now()) {
-        const { store } = db.transaction(type, "readwrite");
-        await store.delete(details.id);
+        const tx = db.transaction(type, "readwrite");
+        await tx.store.delete(details.id);
+        await tx.done;
         isInDB = false;
       }
     }
-    const { store } = db.transaction(type, "readwrite");
-    return isInDB ? await store.put(details) : await store.add(details);
+    const tx = db.transaction(type, "readwrite");
+    const result = isInDB
+      ? await tx.store.put(details)
+      : await tx.store.add(details);
+    // Await commit, not just the request: a later read in its own transaction
+    // may otherwise not see this write.
+    await tx.done;
+    return result;
   },
   /**
    * Closes the underlying database.
@@ -228,5 +236,6 @@ export const biblioDB = {
       return stores.objectStore(name).clear();
     });
     await Promise.all(clearStorePromises);
+    await stores.done;
   },
 };

--- a/tests/spec/core/biblio-db-spec.js
+++ b/tests/spec/core/biblio-db-spec.js
@@ -3,6 +3,15 @@
 import { biblioDB } from "../../../src/core/biblio-db.js";
 
 describe("Core - biblioDB", () => {
+  // biblioDB is a singleton wrapping one persistent IndexedDB, and
+  // biblio-spec.js clears that same database. Without a clean slate per
+  // spec, results depend on which spec ran first and whether its writes
+  // had committed.
+  beforeEach(async () => {
+    await biblioDB.ready;
+    await biblioDB.clear();
+  });
+
   const data = {
     "whatwg-dom": {
       aliasOf: "WHATWG-DOM",


### PR DESCRIPTION
Every write in `biblio-db.js` awaited the IndexedDB request but never the transaction. Per idb's own docs, `tx.done` is what "resolves when the transaction completes successfully", so `await store.add(...)` can resolve before the data is committed and a later read in its own transaction may not see it. All four readwrite transactions now await commit: the expiry sweep in `openIdb`, both paths in `add()`, and `clear()`.

That is the likely cause of a Firefox-only CI failure in `Core - biblioDB` where `find("whatwg-dom")` returned null and the test threw on `r2.title`. `biblio-spec.js` clears the same singleton database, so an uncommitted clear could land after another spec's writes. The spec also had no isolation, so it now clears the database in `beforeEach` and each test seeds what it needs.

I could not reproduce the original failure locally, so this is a correctness fix reasoned from the documented semantics rather than one proven by a red-to-green run. Locally Chrome is 1130 with no failures, and Firefox is 1127 plus 3 accessibility linter failures that fail identically on main.