### PR TITLE
fix(tools): don't charge browser launch against the processing timeout

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -7,6 +7,9 @@ import { readFile } from "fs/promises";
 
 const noop = () => {};
 
+/** Time allowed for the browser process to start, separate from processing. */
+const LAUNCH_TIMEOUT = 120000;
+
 /**
  * Fetches a ReSpec "src" URL, and writes the processed static HTML to an "out" path.
  * @param {string} src A URL or filepath that is the ReSpec source.
@@ -41,7 +44,12 @@ export async function toHTML(src, options = {}) {
   }
 
   const log = msg => options.onProgress(msg, timer.remaining);
-  const timer = createTimer(timeout);
+  /**
+   * Starts once the browser is up, so a slow launch does not eat the caller's
+   * processing budget. `timeout` documents time before *processing* times out.
+   * @type {{ remaining: number }}
+   */
+  let timer = createTimer(timeout);
 
   /** @type {RsError[]} */
   const errors = [];
@@ -65,7 +73,12 @@ export async function toHTML(src, options = {}) {
     args,
     devtools,
     headless: true,
+    // Cold CI runners regularly need longer than puppeteer's 30s default,
+    // which surfaced as "Timed out ... waiting for the WS endpoint URL".
+    timeout: LAUNCH_TIMEOUT,
   });
+  // Charge only document processing against the caller's timeout.
+  timer = createTimer(timeout);
 
   try {
     const page = await browser.newPage();

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -7,7 +7,11 @@ import { readFile } from "fs/promises";
 
 const noop = () => {};
 
-/** Time allowed for the browser process to start, separate from processing. */
+/**
+ * Time allowed for the browser process to start, separate from processing.
+ * Cold CI runners regularly need longer than puppeteer's 30s default,
+ * which surfaced as "Timed out ... waiting for the WS endpoint URL".
+ */
 const LAUNCH_TIMEOUT = 120000;
 
 /**
@@ -47,7 +51,6 @@ export async function toHTML(src, options = {}) {
   /**
    * Starts once the browser is up, so a slow launch does not eat the caller's
    * processing budget. `timeout` documents time before *processing* times out.
-   * @type {{ remaining: number }}
    */
   let timer = createTimer(timeout);
 
@@ -73,8 +76,6 @@ export async function toHTML(src, options = {}) {
     args,
     devtools,
     headless: true,
-    // Cold CI runners regularly need longer than puppeteer's 30s default,
-    // which surfaced as "Timed out ... waiting for the WS endpoint URL".
     timeout: LAUNCH_TIMEOUT,
   });
   // Charge only document processing against the caller's timeout.


### PR DESCRIPTION
The timer started before `puppeteer.launch()`, so time spent starting the browser was deducted from the caller's timeout, which the option documents as time before *processing* times out. On a slow CI runner that starved the actual work: `page.goto` received a `timer.remaining` of zero and the run died with "Timeout: document.respec.ready didn't resolve in 0ms". That is what recently failed a Validate HTML job.

Starting the timer after launch fixes it. With a 5 second delay injected before launch to simulate a cold runner, the budget remaining at navigation goes from 22411ms before this change to 29968ms after, out of 30000ms. At a 30 second launch the old behavior reaches zero, which is the failure.

Launch also had no explicit timeout, so it used puppeteer's 30 second default and surfaced as "Timed out after 30000 ms while waiting for the WS endpoint URL to appear in stdout", which is what recently failed a Headless Tests job. It now gets its own budget, kept separate from processing.