### PR TITLE
fix(w3c/style): always add the dark stylesheet link so the theme toggle appears

### DIFF
--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -126,17 +126,27 @@ export function run(conf) {
     );
     document.head.appendChild(colorScheme);
   }
-  if (colorScheme?.content.includes("dark")) {
-    const darkModeStyleUrl = getStyleUrl("dark.css");
-    document.head.appendChild(
-      html`<link
-        rel="stylesheet"
-        href="${darkModeStyleUrl.href}"
-        media="(prefers-color-scheme: dark)"
-      />`
-    );
+  // W3C's fixup.js only injects the light/dark/auto toggle when it can find the
+  // dark stylesheet link, and it drives that link with `.disabled`. Light-only
+  // specs never had the link, so the toggle silently never appeared (#5200). Add
+  // it either way, switched off when the spec has not opted into dark mode.
+  const darkModeStyleURL = getStyleUrl("dark.css");
+  const isDark = colorScheme.content.includes("dark");
+  const darkLink = html`<link
+    rel="stylesheet"
+    href="${darkModeStyleURL.href}"
+  />`;
+  if (isDark) darkLink.media = "(prefers-color-scheme: dark)";
+  document.head.appendChild(darkLink);
+  if (isDark) {
     // As required by W3C Pub Rules.
-    sub("beforesave", styleMover(darkModeStyleUrl));
+    sub("beforesave", styleMover(darkModeStyleURL));
+  } else {
+    // `disabled` rather than `media="not all"` because fixup.js sets
+    // `darkCss.media = ""`, which would wipe a media query. Must be set after
+    // insertion: per HTML the setter is a no-op while the link's associated CSS
+    // style sheet is still null.
+    darkLink.disabled = true;
   }
 }
 

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -221,6 +221,23 @@ describe("W3C - Style", () => {
     expect(elem.content).toBe("light");
   });
 
+  it("adds a dark mode stylesheet link for light-only specs", async () => {
+    // W3C's fixup.js only injects the light/dark/auto toggle when it finds a
+    // dark stylesheet link, so light-only specs need one present (#5200). Note
+    // the rel filter: a preload hint for the same href exists too.
+    const ops = makeStandardOps();
+    const doc = await makeRSDoc(ops);
+    const meta = doc.querySelector("meta[name='color-scheme']");
+    expect(meta).toBeTruthy();
+    expect(meta.content).toBe("light");
+    const link = doc.querySelector(
+      `link[rel="stylesheet"][href="https://www.w3.org/StyleSheets/TR/2021/dark.css"]`
+    );
+    expect(link).toBeTruthy();
+    // Deliberately not asserting `disabled`: per HTML that setter is a no-op
+    // until the sheet loads, so it would make this test depend on the network.
+  });
+
   it("adds dark mode stylesheet", async () => {
     const ops = makeStandardOps();
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");


### PR DESCRIPTION
Closes #5200

W3C's `fixup.js` only injects the light/dark/auto theme toggle when it finds a dark stylesheet link, since it drives that link's `disabled` property. Light-only specs never got the link, so the whole block was skipped and no toggle appeared. The link is now always added, disabled when the spec has not opted into dark mode.

Intended consequence worth calling out: a light-only spec now gets a working toggle, so a reader can switch it to dark and the dark stylesheet will apply, on a document that never declared `color-scheme`. That is deliberate. Readers get the same control they have on every other TR document, and spec authors should not be deciding this on their behalf.

Two implementation notes for review. The link is disabled after insertion rather than before, because per HTML the `disabled` setter is a no-op while the link's style sheet is still null. And the test asserts only that the link exists, not that it is disabled, since `disabled` depends on the sheet loading from www.w3.org and would make the test network-dependent; the `rel="stylesheet"` filter in the selector matters, because a preload hint for the same href is also present.

Verified in Firefox 153, the browser in the bug report: without the fix the sidebar has no dark stylesheet link, no toggle and no radio inputs; with it, the toggle and all three options appear.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.
