### PR TITLE
fix(tools): check npm auth in the release preflight

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,5 +146,8 @@
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/respec"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/tools/release.cjs
+++ b/tools/release.cjs
@@ -395,22 +395,30 @@ async function preflight() {
   // npm auth. This is the credential that actually expires, and `npm publish` is the LAST step of
   // the release, so without this check the token is discovered to be stale only after main, gh-pages
   // and the tag have all been pushed, leaving the release half-done and needing manual recovery.
-  // The registry is explicit because publish targets public npm while this machine's default
-  // registry may be an internal mirror, so a bare `npm whoami` would check the wrong one.
-  const NPM_REGISTRY = "https://registry.npmjs.org";
-  try {
-    const who = await toExecFilePromise(
-      "npm",
-      ["whoami", "--registry", NPM_REGISTRY],
-      { timeout: 20000, showOutput: false }
-    );
-    console.log(styleText("green", `  ✓ npm auth (${who.trim()})`));
-  } catch {
+  // The registry comes from publishConfig so this probe and the publish below cannot target
+  // different registries: a bare `npm whoami` (or a bare publish) would use the machine default,
+  // which may be an internal mirror.
+  const NPM_REGISTRY = require("../package.json").publishConfig?.registry;
+  if (!NPM_REGISTRY) {
     errors.push(
-      "npm is not authenticated for publishing (the token expires periodically).\n" +
-        `    Check: npm whoami --registry ${NPM_REGISTRY}\n` +
-        `    Fix:   npm login --registry ${NPM_REGISTRY}`
+      "package.json has no publishConfig.registry, so `npm publish` would target whatever\n" +
+        "    registry this machine defaults to. Set it before releasing."
     );
+  } else {
+    try {
+      const who = await toExecFilePromise(
+        "npm",
+        ["whoami", "--registry", NPM_REGISTRY],
+        { timeout: 20000, showOutput: false }
+      );
+      console.log(styleText("green", `  ✓ npm auth (${who.trim()})`));
+    } catch {
+      errors.push(
+        "npm is not authenticated for publishing (the token expires periodically).\n" +
+          `    Check: npm whoami --registry ${NPM_REGISTRY}\n` +
+          `    Fix:   npm login --registry ${NPM_REGISTRY}`
+      );
+    }
   }
 
   // origin/gh-pages must exist and be unambiguous

--- a/tools/release.cjs
+++ b/tools/release.cjs
@@ -392,6 +392,27 @@ async function preflight() {
     );
   }
 
+  // npm auth. This is the credential that actually expires, and `npm publish` is the LAST step of
+  // the release, so without this check the token is discovered to be stale only after main, gh-pages
+  // and the tag have all been pushed, leaving the release half-done and needing manual recovery.
+  // The registry is explicit because publish targets public npm while this machine's default
+  // registry may be an internal mirror, so a bare `npm whoami` would check the wrong one.
+  const NPM_REGISTRY = "https://registry.npmjs.org";
+  try {
+    const who = await toExecFilePromise(
+      "npm",
+      ["whoami", "--registry", NPM_REGISTRY],
+      { timeout: 20000, showOutput: false }
+    );
+    console.log(styleText("green", `  ✓ npm auth (${who.trim()})`));
+  } catch {
+    errors.push(
+      "npm is not authenticated for publishing (the token expires periodically).\n" +
+        `    Check: npm whoami --registry ${NPM_REGISTRY}\n` +
+        `    Fix:   npm login --registry ${NPM_REGISTRY}`
+    );
+  }
+
   // origin/gh-pages must exist and be unambiguous
   try {
     const branches = await git(["branch", "-r", "--list", "*/gh-pages"]);


### PR DESCRIPTION
The npm token expires periodically, and `npm publish` is the last step of the release, so a stale token is discovered only after main, gh-pages and the tag have all been pushed. The release then stops half finished and has to be completed by hand, which has now happened twice. Preflight already validates Java, Chrome, the GitHub CLI and gh-pages, so npm auth belongs there too: with this check the release refuses to start instead of failing after the push.

The registry is explicit because publish targets public npm while the default registry on a given machine may be an internal mirror, so a bare `npm whoami` would validate the wrong one. Verified both ways: with a deliberately bad token in a throwaway config the probe returns `E401 Unauthorized`, and with a valid one the preflight prints `✓ npm auth (marcosc)` and the release proceeds.

Worth noting the limit: this checks that the token authenticates, not that it carries publish rights for this package. If a release ever fails on publish while preflight passed, the next step is to also verify ownership.