### PR TITLE
fix(styles): move the self-link text-decoration onto the anchor

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -162,11 +162,13 @@ aside.example .marker > a.self-link {
   left: -1.1em;
   font-size: 1rem;
   opacity: 0.8;
+  /* Has to be here, not on the ::before: a decoration is painted across the
+     pseudo-element regardless of what the pseudo-element itself declares. */
+  text-decoration: none;
 }
 
 :is(h2, h3, h4, h5, h6) + a.self-link::before {
   content: "§";
-  text-decoration: none;
 }
 
 :is(h2, h3) + a.self-link {

--- a/tests/unit/core/style-spec.js
+++ b/tests/unit/core/style-spec.js
@@ -57,4 +57,18 @@ describe("Core - style", () => {
     darkToggle.checked = false;
     expectRightSources();
   });
+
+  it("does not underline the section self-link", async () => {
+    // A decoration declared on the anchor is painted across its ::before no
+    // matter what the pseudo-element declares, so it has to be off here.
+    const doc = await makePluginDoc(["/src/core/style.js"], {
+      body: `<div><h2 id="two">Two</h2><a class="self-link" href="#two"></a></div>`,
+      style: "display: block", // see makePluginDoc's `style` param
+    });
+    const link = doc.querySelector("a.self-link");
+    expect(link).toBeTruthy();
+    expect(doc.defaultView.getComputedStyle(link).textDecorationLine).toBe(
+      "none"
+    );
+  });
 });


### PR DESCRIPTION
The section self-link's `text-decoration: none` was declared on the `::before` that draws the §, where it has no effect. Per CSS Text Decoration 4, decorations "are also not propagated to inline children of inline boxes, although the decoration is applied to such boxes" — so the anchor's UA underline was still painted under the glyph while the pseudo-element's own `text-decoration` computed to `none`. Moving the same declaration onto the anchor removes it, at rest as well as on hover.

The unit test asserts the anchor's computed `text-decoration-line`, which is the placement that matters; asserting on the pseudo-element would have passed even before this change.

Fixes #5415
