### PR TITLE
fix(styles): stop IDs inside :not() inflating self-link specificity

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -155,7 +155,10 @@ aside.example .marker > a.self-link {
   left: -.5em;
 }
 
-:is(h2, h3, h4, h5, h6):not(#toc h2) + a.self-link {
+/* The #toc exclusion is wrapped in :where() so it contributes no specificity.
+   As a bare :not(#toc h2) its ID outweighed .self-link:hover and killed that
+   rule's opacity: 1. */
+:is(h2, h3, h4, h5, h6):not(:where(#toc h2)) + a.self-link {
   color: inherit;
   order: -1;
   position: relative;

--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -150,7 +150,9 @@ aside.example .marker > a.self-link {
   align-items: baseline;
 }
 
-:is(h2, h3, h4, h5, h6):not(#toc > h2, #abstract > h2, #sotd > h2, .head > h2):has(+ a.self-link) {
+/* :where() again, for the same reason as the rule below: these four IDs would
+   otherwise make this (1, 1, 3) and put it out of reach of ordinary author CSS. */
+:is(h2, h3, h4, h5, h6):not(:where(#toc > h2, #abstract > h2, #sotd > h2, .head > h2)):has(+ a.self-link) {
   position: relative;
   left: -.5em;
 }

--- a/tests/unit/core/style-spec.js
+++ b/tests/unit/core/style-spec.js
@@ -90,4 +90,21 @@ describe("Core - style", () => {
     expect(link).toBeTruthy();
     expect(doc.defaultView.getComputedStyle(link).opacity).toBe("1");
   });
+
+  it("keeps the heading offset rule beatable by ordinary author rules", async () => {
+    // Same trap as above, in the rule that nudges a self-linked heading left:
+    // four IDs inside :not() made it (1, 1, 3), so nothing an author could
+    // reasonably write would override it. The stand-in below is (0, 2, 0), which
+    // should win.
+    const doc = await makePluginDoc(["/src/core/style.js"], {
+      head: `<meta charset="UTF-8" /><style>
+        .probe-a.probe-b { left: 0px; }
+      </style>`,
+      body: `<div><h2 id="two" class="probe-a probe-b">Two</h2><a class="self-link" href="#two"></a></div>`,
+      style: "display: block", // see makePluginDoc's `style` param
+    });
+    const heading = doc.getElementById("two");
+    expect(heading).toBeTruthy();
+    expect(doc.defaultView.getComputedStyle(heading).left).toBe("0px");
+  });
 });

--- a/tests/unit/core/style-spec.js
+++ b/tests/unit/core/style-spec.js
@@ -71,4 +71,23 @@ describe("Core - style", () => {
       "none"
     );
   });
+
+  it("lets .self-link:hover win over the resting opacity", async () => {
+    // :hover cannot be synthesised, so this asserts the thing that was actually
+    // broken: the resting-opacity rule must not OUTWEIGH a selector of the same
+    // specificity as .self-link:hover, which is (0, 2, 0). A bare
+    // :not(#toc h2) contributed an ID, making it (1, 1, 3) and leaving the hover
+    // rule's opacity: 1 dead.
+    const doc = await makePluginDoc(["/src/core/style.js"], {
+      head: `<meta charset="UTF-8" /><style>
+        /* Same specificity as .self-link:hover */
+        .self-link.hover-stand-in { opacity: 1; }
+      </style>`,
+      body: `<div><h2 id="two">Two</h2><a class="self-link hover-stand-in" href="#two"></a></div>`,
+      style: "display: block", // see makePluginDoc's `style` param
+    });
+    const link = doc.querySelector("a.self-link");
+    expect(link).toBeTruthy();
+    expect(doc.defaultView.getComputedStyle(link).opacity).toBe("1");
+  });
 });


### PR DESCRIPTION
Two selectors in `respec.css.js` carried IDs inside `:not()`, which counts toward specificity, putting both rules far out of reach of ordinary author CSS.

The first was a live bug. `.self-link:hover` sets `opacity: 1`, but it never applied: the ID in `:not(#toc h2)` scored the resting-opacity rule at (1, 1, 3) against the hover rule's (0, 2, 0), so `opacity: 0.8` won even while hovering.

The second has no visible symptom yet. The rule that nudges a self-linked heading left carries four IDs in its `:not()`, also making it (1, 1, 3), so nothing a spec author could reasonably write would override it. Fixed at the same time rather than left as a trap for whoever next adds a competing rule there.

Both are fixed by wrapping the exclusion lists in `:where()`, which contributes no specificity. Verified in a browser probe that matching is unchanged in both cases: headings inside `#toc`, `#abstract`, `#sotd` and `.head` are still excluded, a normal self-linked heading is still offset, and one without a self-link is still untouched.

One caveat on the hover test: `:hover` cannot be synthesised in karma, so it asserts against `.self-link.hover-stand-in`, a selector with the same (0, 2, 0) specificity. That covers the mechanism that was broken, but not the literal hover state. The heading-offset test uses the same technique with a `(0, 2, 0)` stand-in for an author rule.

Fixes #5419
