### PR TITLE
fix(tests): bind the headless server to a free port and cover launch time

### DIFF
--- a/tests/headless.cjs
+++ b/tests/headless.cjs
@@ -4,14 +4,43 @@ const { exec } = require("child_process");
 const http = require("http");
 const serveHandler = require("serve-handler");
 
-const port = 8000;
-const timeout = 30; // seconds
+// Budget respec2html gets for processing the document, passed through as --timeout.
+const processingTimeout = 30; // seconds
+
+// Each spec spawns respec2html, which launches a browser before processing starts.
+// tools/respecDocWriter.js gives that launch its own budget (LAUNCH_TIMEOUT, 120s) precisely
+// because a cold runner can be slow, so the spec timeout has to cover launch AND processing.
+// Setting it to the processing budget alone let jasmine kill the child mid-launch, which read
+// as flakiness rather than a timeout.
+const specTimeout = (120 + processingTimeout + 30) * 1000; // launch + processing + slack
 
 describe("Headless (examples)", () => {
-  beforeAll(() => {
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout * 1000;
-    const server = http.createServer(serveHandler);
-    server.listen(port);
+  /** @type {import("http").Server} */
+  let server;
+  /** @type {number} */
+  let port;
+
+  beforeAll(async () => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = specTimeout;
+    server = http.createServer(serveHandler);
+    // Port 0 asks the OS for a free port. A hardcoded port fails whenever something else is
+    // already listening, and worse, a foreign server on it would let these specs pass while
+    // serving someone else's files. Reporting a bind failure here also beats an uncaught
+    // exception attributed to whichever spec happened to be running at the time.
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, () => resolve(undefined));
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error(`Could not determine the test server's port: ${address}`);
+    }
+    port = address.port;
+  });
+
+  afterAll(async () => {
+    if (!server) return;
+    await new Promise(resolve => server.close(() => resolve(undefined)));
   });
 
   it("builds basic.html without errors", async () => {
@@ -41,7 +70,7 @@ describe("Headless (examples)", () => {
 
 function toCommand(src, { useLocal = false } = {}) {
   const command = `node ./tools/respec2html.js ${src}`;
-  const options = ["-e", `--timeout ${timeout}`, "--verbose"];
+  const options = ["-e", `--timeout ${processingTimeout}`, "--verbose"];
   if (useLocal) options.push("--use-local");
   return `${command} ${options.join(" ")}`;
 }

--- a/tests/headless.cjs
+++ b/tests/headless.cjs
@@ -28,8 +28,12 @@ describe("Headless (examples)", () => {
     // serving someone else's files. Reporting a bind failure here also beats an uncaught
     // exception attributed to whichever spec happened to be running at the time.
     await new Promise((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, () => resolve(undefined));
+      const onError = error => reject(error);
+      server.once("error", onError);
+      server.listen(0, () => {
+        server.off("error", onError);
+        resolve(undefined);
+      });
     });
     const address = server.address();
     if (!address || typeof address === "string") {


### PR DESCRIPTION
Three problems in the headless suite, all of which made it look flaky rather than broken.

The server was bound to a hardcoded port 8000 with no error handler, so a bind failure became an uncaught exception attributed to whichever spec happened to be running. Worse, when something else was already serving that port, the specs could pass while exercising that other server files instead of this checkout. That is the dangerous case, because it looks like a green run. It now binds port 0, reads back the assigned port, and a bind failure is reported against the suite with the real error.

The spec timeout was set to the same 30 seconds passed to respec2html as its processing budget. Since browser launch has its own separate budget of 120 seconds, jasmine could kill a child that was still legitimately launching. The spec timeout now covers launch plus processing plus slack.

The server was also never closed; there is now an afterAll for it.

I could not get a green local run to include here: this machine is currently refusing listen on every port including port 0, from every process context, in windows lasting minutes, which is why the failure mode mattered enough to fix. CI is the verification. What I can show is that the new failure output names the cause, "Suite error: listen EPERM ... at tests/headless.cjs:32", instead of blaming an unrelated spec.