### PR TITLE
test: raise the karma jasmine spec timeout above the 5s default

### DIFF
--- a/tests/karma.conf.base.cjs
+++ b/tests/karma.conf.base.cjs
@@ -83,6 +83,13 @@ module.exports = config => {
     client: {
       // @ts-expect-error
       args: ["--grep", config.grep || ""],
+      jasmine: {
+        // Integration specs render whole ReSpec documents, some of which fetch
+        // over the network, so they do not reliably finish inside jasmine's 5s
+        // default when CI runners are loaded. A hung spec still fails, just
+        // later; browserNoActivityTimeout above remains the outer bound.
+        timeoutInterval: 15000,
+      },
     },
   };
 

--- a/tests/unit/karma-config-spec.js
+++ b/tests/unit/karma-config-spec.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// Guards the karma-jasmine `client.jasmine.timeoutInterval` in
+// tests/karma.conf.base.cjs. A misspelled or misplaced karma client option is
+// silently ignored, so without this the suites would quietly fall back to
+// jasmine's 5s default and the flaky timeouts would return unnoticed.
+describe("Karma config", () => {
+  it("raises the jasmine spec timeout above the 5s default", () => {
+    expect(jasmine.DEFAULT_TIMEOUT_INTERVAL).toBe(15000);
+  });
+});


### PR DESCRIPTION
The karma suites run under jasmine's default 5 second per-spec timeout. Integration specs render whole ReSpec documents, some of which fetch over the network, and under CI load they do not reliably finish inside that budget.

Over three consecutive CI runs on one branch, 11 distinct specs failed with no repeats, every one tagged `slow: 5.001 secs`, and the same commit both passed and failed. Main's own push run failed one spec in the same window with unrelated code. Locally the full integration suite passes 1138/0, so there is no defect being masked; the timeout is simply marginal.

Only `tests/test-build.cjs` (60000) and `tests/headless.cjs` set `DEFAULT_TIMEOUT_INTERVAL`; the karma configs never did, so both suites inherited 5000.

The accompanying spec asserts the value reaches the browser. A misspelled or misplaced karma `client` option is silently ignored, so without it the suites could quietly fall back to 5000 and the flakiness would return unnoticed.

This is mitigation rather than a root fix: it lowers the probability of a timeout, it does not remove the network dependency. The root fix is local fixtures for the specs that fetch, which is already noted for the xref tests.

Fixes #5425
