### PR TITLE
fix(tests): run the geonovum specs against the geonovum bundle

### DIFF
--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -272,6 +272,7 @@ export function makeStandardGeoOps(config = {}, body = makeDefaultBody()) {
   return {
     body,
     config: { ...makeBasicConfig("geonovum"), ...config },
+    profile: "geonovum",
   };
 }
 

--- a/tests/spec/geonovum/style-spec.js
+++ b/tests/spec/geonovum/style-spec.js
@@ -20,10 +20,10 @@ async function loadWithStatus(status, expectedURL) {
     profile: "geonovum",
   };
   const doc = await makeRSDoc(ops);
-  const query = `link[href^='${testedURL}']`;
-  const elem = doc.querySelector(query);
-  expect(elem).toBeTruthy();
-  expect(elem.href).toBe(testedURL);
+  // rel=stylesheet: for specStatus "base" the preload resource hint has the
+  // same href, and querySelector would return that hint instead.
+  const query = `link[rel=stylesheet][href='${testedURL}']`;
+  expect(doc.querySelector(query)).toBeTruthy();
   return doc;
 }
 
@@ -66,9 +66,10 @@ describe("Geonovum - Style", () => {
     const ops = makeStandardGeoOps();
     // TODO: create test specs for Geonovum?
     const doc = await makeRSDoc(ops);
-    const query = "script[src^='https://www.w3.org/scripts/TR/2021/fixup.js']";
-    const elem = doc.querySelector(query);
-    expect(elem.src).toBe("https://www.w3.org/scripts/TR/2021/fixup.js");
+    // 2016, not the 2021 the W3C profile emits: this is what proves the
+    // Geonovum bundle ran. See #5409.
+    const query = "script[src='https://www.w3.org/scripts/TR/2016/fixup.js']";
+    expect(doc.querySelector(query)).toBeTruthy();
   });
 
   it("should have a meta viewport added", async () => {
@@ -88,7 +89,7 @@ describe("Geonovum - Style", () => {
   });
 
   it("shouldn't include fixup.js when noTOC is set", async () => {
-    const ops = { ...makeStandardGeoOps({ noTOC: true }), profile: "geonovum" };
+    const ops = makeStandardGeoOps({ noTOC: true });
     const doc = await makeRSDoc(ops);
     const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
     const elem = doc.querySelector(query);
@@ -96,7 +97,7 @@ describe("Geonovum - Style", () => {
   });
 
   it("shouldn't include fixup.js when the deprecated noToc is set", async () => {
-    const ops = { ...makeStandardGeoOps({ noToc: true }), profile: "geonovum" };
+    const ops = makeStandardGeoOps({ noToc: true });
     const doc = await makeRSDoc(ops);
     const query = "script[src^='https://www.w3.org/scripts/TR/2016/fixup.js']";
     const elem = doc.querySelector(query);


### PR DESCRIPTION
The Geonovum specs never passed a profile, so makeRSDoc fell back to its "w3c" default and loaded the W3C bundle, meaning src/geonovum/style.js never ran and the fixup assertion was quietly passing against the W3C 2021 script rather than the 2016 one Geonovum attaches. This also narrows the stylesheet query to rel=stylesheet, because the preload resource hint for base.css carries the same href and made that assertion impossible to fail for specStatus "base". Closes #5409.