### PR TITLE
fix(w3c/style): put the dark stylesheet last on export so the theme toggle works

### DIFF
--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -101,6 +101,32 @@ function styleMover(linkURL) {
 }
 
 /**
+ * Put the dark stylesheet link back into the state ReSpec chose, because by save
+ * time fixup.js has been driving it live: it sets `media = ""` and toggles
+ * `disabled` to follow the reader's theme, and both are reflected content
+ * attributes. Saving a document while the reader had dark selected would
+ * otherwise export an enabled, unconditional dark sheet, which now sits last in
+ * `head` and so wins the cascade, rendering dark for everyone including readers
+ * without scripting.
+ *
+ * @param {Document} exportDoc
+ * @param {boolean} isDark whether the spec itself opted into dark mode
+ */
+function restoreDarkLinkState(exportDoc, isDark) {
+  const darkLink = exportDoc.querySelector(
+    `head link[rel~="stylesheet"][href="${getStyleUrl("dark.css")}"]`
+  );
+  if (!darkLink) return;
+  if (isDark) {
+    darkLink.setAttribute("media", "(prefers-color-scheme: dark)");
+    darkLink.removeAttribute("disabled");
+  } else {
+    darkLink.removeAttribute("media");
+    darkLink.setAttribute("disabled", "");
+  }
+}
+
+/**
  * @param {Conf} conf
  */
 export function run(conf) {
@@ -142,11 +168,17 @@ export function run(conf) {
   if (!isDark) darkLink.setAttribute("disabled", "");
   document.head.appendChild(darkLink);
   // The dark sheet has to end up last. It and base.css set the same `:root`
-  // custom properties at equal specificity, and the mover above puts base.css
-  // at the end of `head` on export, so without this the toggle enables a sheet
-  // that then loses the cascade and the reader sees nothing change. Also what
-  // W3C Pub Rules require for dark-mode specs.
-  sub("beforesave", styleMover(darkModeStyleURL));
+  // custom properties at equal specificity, and the mover above puts the
+  // maturity-level sheet, which `@import`s base.css, at the end of `head` on
+  // export. Without this the toggle enables a sheet that then loses the cascade
+  // and the reader sees nothing change. Also what W3C Pub Rules require.
+  sub(
+    "beforesave",
+    /** @param {Document} exportDoc */ exportDoc => {
+      styleMover(darkModeStyleURL)(exportDoc);
+      restoreDarkLinkState(exportDoc, isDark);
+    }
+  );
 }
 
 /** @param {Conf} conf */

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -158,7 +158,7 @@ export function run(conf) {
   }
   // W3C's fixup.js only injects the light/dark/auto toggle when it can find the
   // dark stylesheet link, and it drives that link with `.disabled`. Light-only
-  // specs never had the link, so the toggle silently never appeared (#5200). Add
+  // specs never had the link, so the toggle silently never appeared. Add
   // it either way, switched off when the spec has not opted into dark mode.
   const darkModeStyleURL = getStyleUrl("dark.css");
   const isDark = colorScheme.content.includes("dark");
@@ -167,8 +167,8 @@ export function run(conf) {
     href="${darkModeStyleURL.href}"
   />`;
   if (isDark) darkLink.media = "(prefers-color-scheme: dark)";
-  // Setting `.disabled` on a still-loading link does not stick in Chrome, and the next write
-  // drops the sheet (#5436), so set the state before the element enters the document.
+  // Set `disabled` before appending: Chrome does not keep it on a link that is still
+  // loading, and the next write to that link drops the sheet.
   if (!isDark) darkLink.setAttribute("disabled", "");
   document.head.appendChild(darkLink);
   // The dark sheet has to end up last. It and base.css set the same `:root`

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -109,15 +109,19 @@ function styleMover(linkURL) {
  * `head` and so wins the cascade, rendering dark for everyone including readers
  * without scripting.
  *
+ * The spec's own intent is read back from the `color-scheme` meta tag rather
+ * than captured when the link was inserted: fixup.js never touches that tag, so
+ * it still says what the spec opted into.
+ *
  * @param {Document} exportDoc
- * @param {boolean} isDark whether the spec itself opted into dark mode
  */
-function restoreDarkLinkState(exportDoc, isDark) {
+function restoreDarkLinkState(exportDoc) {
   const darkLink = exportDoc.querySelector(
     `head link[rel~="stylesheet"][href="${getStyleUrl("dark.css")}"]`
   );
   if (!darkLink) return;
-  if (isDark) {
+  const colorScheme = exportDoc.querySelector("head meta[name=color-scheme]");
+  if (colorScheme?.getAttribute("content")?.includes("dark")) {
     darkLink.setAttribute("media", "(prefers-color-scheme: dark)");
     darkLink.removeAttribute("disabled");
   } else {
@@ -176,7 +180,7 @@ export function run(conf) {
     "beforesave",
     /** @param {Document} exportDoc */ exportDoc => {
       styleMover(darkModeStyleURL)(exportDoc);
-      restoreDarkLinkState(exportDoc, isDark);
+      restoreDarkLinkState(exportDoc);
     }
   );
 }

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -141,10 +141,12 @@ export function run(conf) {
   // drops the sheet (#5436), so set the state before the element enters the document.
   if (!isDark) darkLink.setAttribute("disabled", "");
   document.head.appendChild(darkLink);
-  if (isDark) {
-    // As required by W3C Pub Rules.
-    sub("beforesave", styleMover(darkModeStyleURL));
-  }
+  // The dark sheet has to end up last. It and base.css set the same `:root`
+  // custom properties at equal specificity, and the mover above puts base.css
+  // at the end of `head` on export, so without this the toggle enables a sheet
+  // that then loses the cascade and the reader sees nothing change. Also what
+  // W3C Pub Rules require for dark-mode specs.
+  sub("beforesave", styleMover(darkModeStyleURL));
 }
 
 /** @param {Conf} conf */

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -101,17 +101,16 @@ function styleMover(linkURL) {
 }
 
 /**
- * Put the dark stylesheet link back into the state ReSpec chose, because by save
- * time fixup.js has been driving it live: it sets `media = ""` and toggles
- * `disabled` to follow the reader's theme, and both are reflected content
- * attributes. Saving a document while the reader had dark selected would
- * otherwise export an enabled, unconditional dark sheet, which now sits last in
- * `head` and so wins the cascade, rendering dark for everyone including readers
- * without scripting.
+ * Restores the dark stylesheet link to the state ReSpec chose, in the document being
+ * exported.
  *
- * The spec's own intent is read back from the `color-scheme` meta tag rather
- * than captured when the link was inserted: fixup.js never touches that tag, so
- * it still says what the spec opted into.
+ * Keep this on the `beforesave` path: fixup.js drives that link live to follow the reader's
+ * theme, and `media` and `disabled` are reflected content attributes, so a spec saved while
+ * dark was showing would otherwise publish an unconditional dark sheet that every reader
+ * gets, scripting or not.
+ *
+ * Intent comes from the `color-scheme` meta tag rather than a flag captured at insert time,
+ * because fixup.js never touches that tag.
  *
  * @param {Document} exportDoc
  */
@@ -156,10 +155,8 @@ export function run(conf) {
     );
     document.head.appendChild(colorScheme);
   }
-  // W3C's fixup.js only injects the light/dark/auto toggle when it can find the
-  // dark stylesheet link, and it drives that link with `.disabled`. Light-only
-  // specs never had the link, so the toggle silently never appeared. Add
-  // it either way, switched off when the spec has not opted into dark mode.
+  // Add the link even for a light-only spec, switched off: fixup.js injects the
+  // light/dark/auto toggle only when it can find this link, and drives it with `.disabled`.
   const darkModeStyleURL = getStyleUrl("dark.css");
   const isDark = colorScheme.content.includes("dark");
   const darkLink = html`<link
@@ -171,11 +168,10 @@ export function run(conf) {
   // loading, and the next write to that link drops the sheet.
   if (!isDark) darkLink.setAttribute("disabled", "");
   document.head.appendChild(darkLink);
-  // The dark sheet has to end up last. It and base.css set the same `:root`
-  // custom properties at equal specificity, and the mover above puts the
-  // maturity-level sheet, which `@import`s base.css, at the end of `head` on
-  // export. Without this the toggle enables a sheet that then loses the cascade
-  // and the reader sees nothing change. Also what W3C Pub Rules require.
+  // Move the dark sheet too, or the toggle enables a sheet that then loses the cascade and
+  // the reader sees nothing change: it and base.css set the same `:root` custom properties
+  // at equal specificity, and the mover above puts the maturity-level sheet, which
+  // `@import`s base.css, at the end of `head`.
   sub(
     "beforesave",
     /** @param {Document} exportDoc */ exportDoc => {

--- a/tests/darkmode-race.cjs
+++ b/tests/darkmode-race.cjs
@@ -1,5 +1,5 @@
-// Regression test for speced/respec#5436. Only Chrome reproduces the race, so this passes on
-// other engines whether or not the fix is present.
+// Only Chrome reproduces the race, so this passes on other engines whether or not the fix
+// is present.
 const http = require("http");
 const path = require("path");
 const fs = require("fs");
@@ -12,7 +12,7 @@ const LIGHT = "rgb(255, 255, 255)";
 // tools/respecDocWriter.js and tests/headless.cjs both budget 120s for.
 const LAUNCH_TIMEOUT = 120000;
 
-describe("W3C - Style - dark stylesheet arriving late (#5436)", () => {
+describe("W3C - Style - dark stylesheet arriving late", () => {
   let server;
   let browser;
   let port;

--- a/tests/spec/core/exporter-spec.js
+++ b/tests/spec/core/exporter-spec.js
@@ -68,7 +68,7 @@ describe("Core - exporter", () => {
     expect(dfn.hasAttribute("data-keep-me")).toBeTrue();
   });
 
-  it("moves the W3C style sheets to be the last things in documents head", async () => {
+  it("moves the W3C style sheets to be the last things in the document's head", async () => {
     const ops = makeStandardOps({ specStatus: "ED", group: "webapps" });
     ops.body = `
       <!-- add WebIDL style -->

--- a/tests/spec/core/exporter-spec.js
+++ b/tests/spec/core/exporter-spec.js
@@ -81,9 +81,8 @@ describe("Core - exporter", () => {
       </pre>`;
     const doc = await getExportedDoc(await makeRSDoc(ops));
     const { lastElementChild } = doc.head;
-    // The dark sheet sits after the maturity-level sheet: both set the same
-    // `:root` custom properties at equal specificity, so the dark one has to
-    // come last to win once the theme toggle enables it.
+    // dark.css last, maturity sheet second-last: reversing them makes the theme toggle a
+    // no-op, so assert both positions rather than membership.
     expect(lastElementChild.href).toBe(
       "https://www.w3.org/StyleSheets/TR/2021/dark.css"
     );

--- a/tests/spec/core/exporter-spec.js
+++ b/tests/spec/core/exporter-spec.js
@@ -68,7 +68,7 @@ describe("Core - exporter", () => {
     expect(dfn.hasAttribute("data-keep-me")).toBeTrue();
   });
 
-  it("moves the W3C style sheet to be last thing in documents head", async () => {
+  it("moves the W3C style sheets to be the last things in documents head", async () => {
     const ops = makeStandardOps({ specStatus: "ED", group: "webapps" });
     ops.body = `
       <!-- add WebIDL style -->
@@ -81,7 +81,13 @@ describe("Core - exporter", () => {
       </pre>`;
     const doc = await getExportedDoc(await makeRSDoc(ops));
     const { lastElementChild } = doc.head;
+    // The dark sheet sits after the maturity-level sheet: both set the same
+    // `:root` custom properties at equal specificity, so the dark one has to
+    // come last to win once the theme toggle enables it.
     expect(lastElementChild.href).toBe(
+      "https://www.w3.org/StyleSheets/TR/2021/dark.css"
+    );
+    expect(lastElementChild.previousElementSibling.href).toBe(
       "https://www.w3.org/StyleSheets/TR/2021/W3C-ED"
     );
   });

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -199,13 +199,23 @@ describe("W3C - Style", () => {
     });
   }
 
-  it("should add W3C stylesheet at the end", async () => {
+  it("puts the dark stylesheet last, after the W3C stylesheet", async () => {
+    // The dark sheet has to win the cascade, because it and base.css set the
+    // same `:root` custom properties at equal specificity. If base.css lands
+    // after it, fixup.js's toggle enables a sheet that then loses, and the
+    // reader sees nothing happen.
     const ops = makeStandardOps({});
     const doc = await getExportedDoc(await makeRSDoc(ops));
-    const url = "https://www.w3.org/StyleSheets/TR/2021/base";
-    const elem = doc.querySelector(`link[href^='${url}'][rel="stylesheet"]`);
-    expect(elem).toBeTruthy();
-    expect(elem.nextElementSibling).toBe(null);
+    const base = doc.querySelector(
+      `link[rel="stylesheet"][href^='https://www.w3.org/StyleSheets/TR/2021/base']`
+    );
+    const dark = doc.querySelector(
+      `link[rel="stylesheet"][href='https://www.w3.org/StyleSheets/TR/2021/dark.css']`
+    );
+    expect(base).toBeTruthy();
+    expect(dark).toBeTruthy();
+    expect(base.nextElementSibling).toBe(dark);
+    expect(dark.nextElementSibling).toBe(null);
   });
 
   it("respects existing color scheme", async () => {

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -218,6 +218,70 @@ describe("W3C - Style", () => {
     expect(dark.nextElementSibling).toBe(null);
   });
 
+  it("disables the dark stylesheet in the live document for a light-only spec", async () => {
+    // Uses noTOC deliberately: with the TOC on, fixup.js is attached and sets
+    // `disabled` itself, so the assertion would pass whether or not ReSpec did
+    // it. With noTOC there is no fixup.js, so ReSpec's own `disabled` is the
+    // only thing keeping the sheet off, and a light-only spec would otherwise
+    // render dark permanently.
+    const doc = await makeRSDoc(makeStandardOps({ noTOC: true }));
+    const link = doc.querySelector(
+      `link[rel~="stylesheet"][href="https://www.w3.org/StyleSheets/TR/2021/dark.css"]`
+    );
+    expect(link).toBeTruthy();
+    expect(link.hasAttribute("disabled")).toBeTrue();
+  });
+
+  it("exports the dark stylesheet disabled even if the reader was in dark mode", async () => {
+    // fixup.js drives this link live to follow the reader's theme, and both
+    // `disabled` and `media` are reflected content attributes. Since the dark
+    // sheet now sits last in `head`, a document saved while dark was selected
+    // would otherwise export an enabled, unconditional dark sheet and render
+    // dark for everyone.
+    //
+    // Asserted against the serialized HTML rather than getExportedDoc(), because
+    // the export carries the fixup.js script tag: re-parsing it into an iframe
+    // lets fixup.js run again and re-mutate the link, so a re-hydrated document
+    // does not tell you what was published.
+    const rsDoc = await makeRSDoc(makeStandardOps({}));
+    const live = rsDoc.querySelector(
+      `link[rel~="stylesheet"][href="https://www.w3.org/StyleSheets/TR/2021/dark.css"]`
+    );
+    expect(live).toBeTruthy();
+    // The state fixup.js leaves behind once the reader picks dark. Set as
+    // attributes rather than through `link.disabled`, because that setter is a
+    // no-op while the sheet is still null and these tests never load it.
+    live.removeAttribute("disabled");
+    live.setAttribute("media", "");
+
+    const html = await rsDoc.respec.toHTML();
+    const [tag] = html.match(/<link[^>]*dark\.css[^>]*>/g) ?? [];
+    expect(tag).toBeTruthy();
+    expect(tag).toContain("disabled");
+    expect(tag).not.toContain("media=");
+  });
+
+  it("exports the dark stylesheet media-gated for a spec that opted in", async () => {
+    // Same leak in the other direction: fixup.js sets `media = ""` on load, so
+    // without restoring it an opted-in spec exports a sheet that applies at all
+    // times instead of only when the reader prefers dark.
+    const rsDoc = await makeRSDoc(
+      makeStandardOps(),
+      "spec/core/color-scheme.html"
+    );
+    const live = rsDoc.querySelector(
+      `link[rel~="stylesheet"][href="https://www.w3.org/StyleSheets/TR/2021/dark.css"]`
+    );
+    expect(live).toBeTruthy();
+    live.setAttribute("media", "");
+
+    const html = await rsDoc.respec.toHTML();
+    const [tag] = html.match(/<link[^>]*dark\.css[^>]*>/g) ?? [];
+    expect(tag).toBeTruthy();
+    expect(tag).toContain('media="(prefers-color-scheme: dark)"');
+    expect(tag).not.toContain("disabled");
+  });
+
   it("respects existing color scheme", async () => {
     const ops = makeStandardOps();
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -200,10 +200,8 @@ describe("W3C - Style", () => {
   }
 
   it("puts the dark stylesheet last, after the W3C stylesheet", async () => {
-    // The dark sheet has to win the cascade, because it and base.css set the
-    // same `:root` custom properties at equal specificity. If base.css lands
-    // after it, fixup.js's toggle enables a sheet that then loses, and the
-    // reader sees nothing happen.
+    // The order is the assertion: dark.css and base.css set the same `:root` custom
+    // properties at equal specificity, so base.css landing last makes the toggle a no-op.
     const ops = makeStandardOps({});
     const doc = await getExportedDoc(await makeRSDoc(ops));
     const base = doc.querySelector(
@@ -219,11 +217,8 @@ describe("W3C - Style", () => {
   });
 
   it("disables the dark stylesheet in the live document for a light-only spec", async () => {
-    // Uses noTOC deliberately: with the TOC on, fixup.js is attached and sets
-    // `disabled` itself, so the assertion would pass whether or not ReSpec did
-    // it. With noTOC there is no fixup.js, so ReSpec's own `disabled` is the
-    // only thing keeping the sheet off, and a light-only spec would otherwise
-    // render dark permanently.
+    // Keep `noTOC`: it is the one configuration with no fixup.js, which would otherwise set
+    // `disabled` itself and make this pass whether or not ReSpec did.
     const doc = await makeRSDoc(makeStandardOps({ noTOC: true }));
     const link = doc.querySelector(
       `link[rel~="stylesheet"][href="https://www.w3.org/StyleSheets/TR/2021/dark.css"]`
@@ -239,18 +234,15 @@ describe("W3C - Style", () => {
     // would otherwise export an enabled, unconditional dark sheet and render
     // dark for everyone.
     //
-    // Asserted against the serialized HTML rather than getExportedDoc(), because
-    // the export carries the fixup.js script tag: re-parsing it into an iframe
-    // lets fixup.js run again and re-mutate the link, so a re-hydrated document
-    // does not tell you what was published.
+    // Match the serialized string, not getExportedDoc(): the export carries the fixup.js
+    // script tag, so re-parsing it into an iframe lets fixup.js re-mutate the link.
     const rsDoc = await makeRSDoc(makeStandardOps({}));
     const live = rsDoc.querySelector(
       `link[rel~="stylesheet"][href="https://www.w3.org/StyleSheets/TR/2021/dark.css"]`
     );
     expect(live).toBeTruthy();
-    // The state fixup.js leaves behind once the reader picks dark. Set as
-    // attributes rather than through `link.disabled`, because that setter is a
-    // no-op while the sheet is still null and these tests never load it.
+    // Drive these with setAttribute, not `link.disabled`: the property setter is a no-op
+    // while `link.sheet` is null, which it always is here since the sheet never loads.
     live.removeAttribute("disabled");
     live.setAttribute("media", "");
 
@@ -262,9 +254,8 @@ describe("W3C - Style", () => {
   });
 
   it("exports the dark stylesheet media-gated for a spec that opted in", async () => {
-    // Same leak in the other direction: fixup.js sets `media = ""` on load, so
-    // without restoring it an opted-in spec exports a sheet that applies at all
-    // times instead of only when the reader prefers dark.
+    // fixup.js sets `media = ""` on load, so without restoring it an opted-in spec exports
+    // a sheet that applies at all times.
     const rsDoc = await makeRSDoc(
       makeStandardOps(),
       "spec/core/color-scheme.html"


### PR DESCRIPTION
Refs #5200, and fixes a regression from #5408. On an exported spec that never opted into dark mode the theme toggle did nothing: `styleMover` was subscribed for the maturity stylesheet unconditionally but for `dark.css` only when the spec had opted in, so on save the maturity sheet moved past it and won the cascade. The dark sheet now moves for every spec, and its `disabled` and `media` state is restored on export, so a document saved while the reader had dark selected no longer ships a permanently dark spec.

Two existing tests asserted the old order and were rewritten.

This makes dark mode reachable where it previously did nothing, which exposes that several of ReSpec's own stylesheets are not dark-ready yet. Those are separate PRs and no release should go out before they land.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.

<!-- ai-proof:start -->

Proof: the same source exported with the base build and with this branch. Without the fix `dark.css` lands before `W3C-ED` and enabling it changes nothing; with the fix it lands last and the toggle works. Marcos then confirmed it manually on exported specs: https://github.com/speced/respec/pull/5436#issuecomment-5437023397
<!-- ai-proof:
{
  "mode": "reverted-fix",
  "base": "648a3f06",
  "head": "c87427c1",
  "repro": "export the same spec with each build and compare the stylesheet order and the dark link's disabled/media state",
  "before": "failed",
  "after": "passed",
  "blocker": "the regression tests that pin this do not exist on the base commit, so base-sha cannot run them"
}
-->
<!-- ai-proof:end -->
