### PR TITLE
feat(w3c/style): let an editor turn dark mode off with darkMode: false

### DIFF
--- a/src/core/insert-style.js
+++ b/src/core/insert-style.js
@@ -2,12 +2,13 @@
 // Module core/insert-style
 // One place where ReSpec adds its own `<style>` elements to the head.
 //
-// Going through here is also what lets `disableDarkStyles()` rewrite ReSpec's CSS without
-// ever reading the spec author's: this module only sees strings ReSpec handed it.
+// Add ReSpec's stylesheets through here and nowhere else: `disableDarkStyles()` rewrites what
+// this module inserted, so anything added directly is beyond its reach, and a spec author's
+// own `<style>` stays out of its reach for the same reason.
 
 export const name = "core/insert-style";
 
-/** The elements this module created, so `disableDarkStyles` can revisit them. */
+/** The stylesheets `disableDarkStyles()` rewrites. */
 const inserted = new Set();
 
 let darkStylesDisabled = false;
@@ -15,38 +16,30 @@ let darkStylesDisabled = false;
 /**
  * Removes every `@media` block that requests a dark color scheme.
  *
- * Pass only ReSpec's own CSS. This counts braces rather than parsing, so a `{` or `}` inside
- * a string or a comment miscounts the depth. An unterminated block is left alone rather than
- * truncating the sheet, but a comment holding a dark `@media` opener still swallows the rules
- * after it.
+ * CSS with nothing to remove comes back untouched. Anything else comes back through the
+ * browser's CSS parser, so formatting is normalized, comments are gone, and whatever the
+ * parser rejects is dropped rather than passed along.
+ *
+ * `not (prefers-color-scheme: dark)` is kept: it forces a page light, so removing it would do
+ * the opposite of what the caller asked for.
  *
  * @param {string} css
  * @returns {string}
  */
 export function stripDarkMediaBlocks(css) {
-  // `(?!\s*not\b)` because `not (prefers-color-scheme: dark)` is what keeps a page light:
-  // deleting it would do the opposite of what the caller asked for.
-  const opener =
-    /@media(?!\s*not\b)[^{]*prefers-color-scheme\s*:\s*dark[^{]*\{/gi;
-  let out = "";
-  let copiedTo = 0;
-  let match;
-  while ((match = opener.exec(css)) !== null) {
-    let depth = 1;
-    let i = opener.lastIndex;
-    while (i < css.length && depth > 0) {
-      if (css[i] === "{") depth++;
-      else if (css[i] === "}") depth--;
-      i++;
-    }
-    // Depth still open means the braces never balanced, so the end of the block is unknown.
-    // Copying up to `i` here would delete every rule after it, silently.
-    if (depth > 0) break;
-    out += css.slice(copiedTo, match.index);
-    copiedTo = i;
-    opener.lastIndex = i;
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(css);
+  const kept = [];
+  let removed = false;
+  for (const rule of sheet.cssRules) {
+    const isDarkMedia =
+      rule instanceof CSSMediaRule &&
+      /prefers-color-scheme\s*:\s*dark/i.test(rule.conditionText) &&
+      !/\bnot\b/i.test(rule.conditionText);
+    if (isDarkMedia) removed = true;
+    else kept.push(rule.cssText);
   }
-  return copiedTo === 0 ? css : out + css.slice(copiedTo);
+  return removed ? kept.join("\n") : css;
 }
 
 /**
@@ -74,15 +67,14 @@ export function insertStyle(css, { id, className, before } = {}) {
 }
 
 /**
- * Drop ReSpec's dark rules from the stylesheets it has already added, and from any it adds
+ * Removes ReSpec's dark rules from the stylesheets it has already added, and from any added
  * afterwards.
  *
- * Revisiting the existing ones is what frees callers from caring about order: profile
- * modules are imported with `Promise.all`, so a module that inserted at import time, before
- * any config was read, still gets corrected here.
+ * Existing ones have to be revisited because profile modules are imported with `Promise.all`,
+ * so several insert their stylesheets before any config is read.
  *
- * The flag lives for the life of the realm, and every path today builds one document per
- * realm, so that is not observable. A host building two specs in one realm would carry it over.
+ * The flag lives for the life of the realm. Every path today builds one document per realm, so
+ * a second spec in the same realm would inherit it.
  */
 export function disableDarkStyles() {
   darkStylesDisabled = true;

--- a/src/core/insert-style.js
+++ b/src/core/insert-style.js
@@ -1,8 +1,45 @@
 // @ts-check
 // Module core/insert-style
 // One place where ReSpec adds its own `<style>` elements to the head.
+//
+// Going through here is also what lets `disableDarkStyles()` rewrite ReSpec's CSS without
+// ever reading the spec author's: this module only sees strings ReSpec handed it.
 
 export const name = "core/insert-style";
+
+/** The elements this module created, so `disableDarkStyles` can revisit them. */
+const inserted = new Set();
+
+let darkStylesDisabled = false;
+
+/**
+ * Removes every `@media` block asking for a dark color scheme.
+ *
+ * Pass only ReSpec's own CSS: a `{` or `}` inside a string or comment miscounts the depth
+ * and swallows the rest of the sheet.
+ *
+ * @param {string} css
+ * @returns {string}
+ */
+export function stripDarkMediaBlocks(css) {
+  const opener = /@media[^{]*prefers-color-scheme\s*:\s*dark[^{]*\{/gi;
+  let out = "";
+  let copiedTo = 0;
+  let match;
+  while ((match = opener.exec(css)) !== null) {
+    let depth = 1;
+    let i = opener.lastIndex;
+    while (i < css.length && depth > 0) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") depth--;
+      i++;
+    }
+    out += css.slice(copiedTo, match.index);
+    copiedTo = i;
+    opener.lastIndex = i;
+  }
+  return copiedTo === 0 ? css : out + css.slice(copiedTo);
+}
 
 /**
  * Add one of ReSpec's stylesheets to the head.
@@ -20,9 +57,30 @@ export function insertStyle(css, { id, className, before } = {}) {
   // Explicit undefined check: `style.className = undefined` would serialize as
   // `class="undefined"`, and callers pass "" to mean "no classes".
   if (className !== undefined) style.className = className;
-  style.textContent = css;
+  style.textContent = darkStylesDisabled ? stripDarkMediaBlocks(css) : css;
   // Insert through `head` rather than `before.before(style)`, which would let the anchor
   // choose the parent and put ReSpec's CSS in the body for an anchor that lives there.
   document.head.insertBefore(style, before ?? null);
+  inserted.add(style);
   return style;
+}
+
+/**
+ * Drop ReSpec's dark rules from the stylesheets it has already added, and from any it adds
+ * afterwards.
+ *
+ * Revisiting the existing ones is what frees callers from caring about order: profile
+ * modules are imported with `Promise.all`, so a module that inserted at import time, before
+ * any config was read, still gets corrected here.
+ *
+ * The flag lives for the life of the realm. Every path today builds one document per realm
+ * (a puppeteer page per document, an iframe per karma spec), so that is not observable; a
+ * host that built two specs in one realm would carry it over.
+ */
+export function disableDarkStyles() {
+  darkStylesDisabled = true;
+  inserted.forEach(style => {
+    const stripped = stripDarkMediaBlocks(style.textContent);
+    if (stripped !== style.textContent) style.textContent = stripped;
+  });
 }

--- a/src/core/insert-style.js
+++ b/src/core/insert-style.js
@@ -13,16 +13,21 @@ const inserted = new Set();
 let darkStylesDisabled = false;
 
 /**
- * Removes every `@media` block asking for a dark color scheme.
+ * Removes every `@media` block that requests a dark color scheme.
  *
- * Pass only ReSpec's own CSS: a `{` or `}` inside a string or comment miscounts the depth
- * and swallows the rest of the sheet.
+ * Pass only ReSpec's own CSS. This counts braces rather than parsing, so a `{` or `}` inside
+ * a string or a comment miscounts the depth. An unterminated block is left alone rather than
+ * truncating the sheet, but a comment holding a dark `@media` opener still swallows the rules
+ * after it.
  *
  * @param {string} css
  * @returns {string}
  */
 export function stripDarkMediaBlocks(css) {
-  const opener = /@media[^{]*prefers-color-scheme\s*:\s*dark[^{]*\{/gi;
+  // `(?!\s*not\b)` because `not (prefers-color-scheme: dark)` is what keeps a page light:
+  // deleting it would do the opposite of what the caller asked for.
+  const opener =
+    /@media(?!\s*not\b)[^{]*prefers-color-scheme\s*:\s*dark[^{]*\{/gi;
   let out = "";
   let copiedTo = 0;
   let match;
@@ -34,6 +39,9 @@ export function stripDarkMediaBlocks(css) {
       else if (css[i] === "}") depth--;
       i++;
     }
+    // Depth still open means the braces never balanced, so the end of the block is unknown.
+    // Copying up to `i` here would delete every rule after it, silently.
+    if (depth > 0) break;
     out += css.slice(copiedTo, match.index);
     copiedTo = i;
     opener.lastIndex = i;
@@ -73,9 +81,8 @@ export function insertStyle(css, { id, className, before } = {}) {
  * modules are imported with `Promise.all`, so a module that inserted at import time, before
  * any config was read, still gets corrected here.
  *
- * The flag lives for the life of the realm. Every path today builds one document per realm
- * (a puppeteer page per document, an iframe per karma spec), so that is not observable; a
- * host that built two specs in one realm would carry it over.
+ * The flag lives for the life of the realm, and every path today builds one document per
+ * realm, so that is not observable. A host building two specs in one realm would carry it over.
  */
 export function disableDarkStyles() {
   darkStylesDisabled = true;

--- a/src/core/insert-style.js
+++ b/src/core/insert-style.js
@@ -2,9 +2,9 @@
 // Module core/insert-style
 // One place where ReSpec adds its own `<style>` elements to the head.
 //
-// Add ReSpec's stylesheets through here and nowhere else: `disableDarkStyles()` rewrites what
-// this module inserted, so anything added directly is beyond its reach, and a spec author's
-// own `<style>` stays out of its reach for the same reason.
+// `disableDarkStyles()` only rewrites what this module inserted, so a stylesheet created
+// directly with `createElement` will not be reached, and a spec author's own `<style>` is out
+// of reach for the same reason.
 
 export const name = "core/insert-style";
 
@@ -26,7 +26,7 @@ let darkStylesDisabled = false;
  * @param {string} css
  * @returns {string}
  */
-export function stripDarkMediaBlocks(css) {
+function stripDarkMediaBlocks(css) {
   const sheet = new CSSStyleSheet();
   sheet.replaceSync(css);
   const kept = [];
@@ -68,7 +68,11 @@ export function insertStyle(css, { id, className, before } = {}) {
 
 /**
  * Removes ReSpec's dark rules from the stylesheets it has already added, and from any added
- * afterwards.
+ * afterwards. Call it when an editor has set `darkMode: false`.
+ *
+ * It only reaches stylesheets that went through `insertStyle`, so a spec author's own
+ * `<style>` is never rewritten, and neither is anything ReSpec created directly with
+ * `createElement`.
  *
  * Existing ones have to be revisited because profile modules are imported with `Promise.all`,
  * so several insert their stylesheets before any config is read.

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -126,14 +126,9 @@ interface Conf {
   /** Disables injecting ReSpec styles */
   noReSpecCSS?: boolean;
   /**
-   * Whether this spec offers readers dark mode. Defaults to true. Set it to
-   * exactly `false` and ReSpec emits no dark stylesheet, so W3C's fixup.js finds
-   * nothing to toggle and readers get no theme picker; ReSpec also deletes its own
-   * dark styles, so a reader whose operating system prefers dark does not get a
-   * light page with dark ReSpec components in it.
-   *
-   * Use this only while your custom CSS is not dark-aware yet. Fix the CSS and
-   * remove the option; it is transitional and will go away.
+   * Set to `false` to turn dark mode off for this spec: no theme picker, and
+   * ReSpec's own dark styles are removed. Transitional, for custom CSS that is
+   * not dark-aware yet.
    */
   darkMode?: boolean;
 

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -125,6 +125,17 @@ interface Conf {
   noTOC?: boolean;
   /** Disables injecting ReSpec styles */
   noReSpecCSS?: boolean;
+  /**
+   * Whether this spec offers readers dark mode. Defaults to true. Set it to
+   * exactly `false` and ReSpec emits no dark stylesheet, so W3C's fixup.js finds
+   * nothing to toggle and readers get no theme picker; ReSpec also deletes its own
+   * dark styles, so a reader whose operating system prefers dark does not get a
+   * light page with dark ReSpec components in it.
+   *
+   * Use this only while your custom CSS is not dark-aware yet. Fix the CSS and
+   * remove the option; it is transitional and will go away.
+   */
+  darkMode?: boolean;
 
   /** Indicates whether the document is a preview */
   isPreview?: boolean;

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -146,6 +146,9 @@ export function run(conf) {
   // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
   sub("beforesave", styleMover(finalStyleURL));
 
+  // Keep this `=== false` and keep the early return. A falsy test would turn dark mode off on
+  // every spec that never set the option, and the code below reads `colorScheme.content`,
+  // which throws once the meta is no longer injected.
   if (conf.darkMode === false) {
     disableDarkStyles();
     // Without this the page still downloads dark.css, which it will never apply.

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -6,6 +6,7 @@
 
 import { W3CNotes, recTrackStatus, registryTrackStatus } from "./headers.js";
 import { createResourceHint } from "../core/utils.js";
+import { disableDarkStyles } from "../core/insert-style.js";
 import { html } from "../core/import-maps.js";
 import { sub } from "../core/pubsubhub.js";
 
@@ -87,19 +88,6 @@ if (!document.head.querySelector("meta[name=viewport]")) {
 
 document.head.prepend(elements);
 
-// The author's own `<style>` elements, captured before ReSpec injects more, so the
-// dark-mode strip below leaves them alone the way Bikeshed leaves author CSS alone.
-// This excludes ReSpec's two stylesheets that carry an id by id rather than by
-// timing, because `profiles/w3c.js` imports modules concurrently and nothing
-// guarantees `core/style.js` has injected `#respec-mainstyle` before this module is
-// evaluated. Excluding by id is correct whichever order they happen to run in.
-const RESPEC_STYLE_IDS = ["respec-mainstyle", "baseline-stylesheet"];
-const authorStyles = new Set(
-  [...document.querySelectorAll("head style")].filter(
-    el => !RESPEC_STYLE_IDS.includes(el.id)
-  )
-);
-
 /**
  * @param {URL|string} linkURL
  * @returns {(exportDoc: Document) => void}
@@ -111,63 +99,6 @@ function styleMover(linkURL) {
       exportDoc.querySelector("head")?.append(w3cStyle);
     }
   };
-}
-
-/**
- * Remove every `@media (prefers-color-scheme: dark)` block from a stylesheet.
- *
- * Brace counting rather than Bikeshed's left-margin regex (`manager.py:250-270`),
- * because ReSpec's stylesheets reach the page from a minified bundle: there is no
- * newline to anchor to, the whole sheet is one line. Counts braces from the block's
- * opening one, so it works on minified and readable CSS alike.
- *
- * Known limit: a `{` or `}` inside a string or comment would miscount. None of
- * ReSpec's stylesheets contain one, and this only ever runs over ReSpec's own.
- *
- * @param {string} css
- * @returns {string}
- */
-export function stripDarkMediaBlocks(css) {
-  const opener = /@media[^{]*prefers-color-scheme\s*:\s*dark[^{]*\{/gi;
-  let out = "";
-  let copiedTo = 0;
-  let match;
-  while ((match = opener.exec(css)) !== null) {
-    let depth = 1;
-    let i = opener.lastIndex;
-    while (i < css.length && depth > 0) {
-      if (css[i] === "{") depth++;
-      else if (css[i] === "}") depth--;
-      i++;
-    }
-    out += css.slice(copiedTo, match.index);
-    copiedTo = i;
-    opener.lastIndex = i;
-  }
-  return copiedTo === 0 ? css : out + css.slice(copiedTo);
-}
-
-/**
- * Strips ReSpec's own dark styles, the way Bikeshed's `removeInlineDarkStyles()`
- * strips its own, once the editor has turned dark mode off.
- *
- * Skip this and the browser paints a light page with dark ReSpec components for
- * anyone whose operating system prefers dark: dark CDDL tokens, a dark `.assert`
- * block, dark baseline pills. Nothing else can prevent that. Those blocks are
- * media queries, and neither CSS nor a meta tag can stop a media query matching,
- * which I measured in Safari 27, Chrome 151 and Firefox 153. Deleting the text is
- * the only lever ReSpec has.
- *
- * This runs once on `end-all`. That is late enough because every module injects
- * its stylesheet from `run()` or `prepare()`, and no module injects one at or
- * after `end-all`.
- */
-function stripReSpecDarkStyles() {
-  for (const style of document.querySelectorAll("head style")) {
-    if (authorStyles.has(style)) continue;
-    const stripped = stripDarkMediaBlocks(style.textContent);
-    if (stripped !== style.textContent) style.textContent = stripped;
-  }
 }
 
 /**
@@ -215,28 +146,14 @@ export function run(conf) {
   // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
   sub("beforesave", styleMover(finalStyleURL));
 
-  // The editor has turned dark mode off, so do what Bikeshed's `Dark Mode: off`
-  // does: emit no `color-scheme` meta and no dark stylesheet link
-  // (`boilerplate.py:1293` returns before it writes either), and strip dark blocks
-  // out of our own styles. Omitting the link is the whole mechanism, because
-  // fixup.js only builds the theme toggle when it finds that link.
-  //
-  // Strictly `=== false`. Absent is the default and `undefined` is falsy, so a
-  // general falsy test would have disabled dark mode on every spec that never set
-  // the option. Returning here also matters: the code below reads
-  // `colorScheme.content`, which would throw once the meta is no longer injected.
   if (conf.darkMode === false) {
-    // `createResourceHints()` above adds the preload hint at import time, before
-    // any config exists, so this is the only place that can remove it. Worth doing:
-    // a spec whose editor turned dark mode off should not fetch a stylesheet it
-    // will never apply, and anyone searching for `link[href$="dark.css"]` would
-    // still find the leftover hint.
+    disableDarkStyles();
+    // Without this the page still downloads dark.css, which it will never apply.
     document
       .querySelector(
         `head link[rel~="preload"][href="${getStyleUrl("dark.css")}"]`
       )
       ?.remove();
-    sub("end-all", stripReSpecDarkStyles, { once: true });
     return;
   }
 

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -87,6 +87,19 @@ if (!document.head.querySelector("meta[name=viewport]")) {
 
 document.head.prepend(elements);
 
+// The author's own `<style>` elements, captured before ReSpec injects more, so the
+// dark-mode strip below leaves them alone the way Bikeshed leaves author CSS alone.
+// This excludes ReSpec's two stylesheets that carry an id by id rather than by
+// timing, because `profiles/w3c.js` imports modules concurrently and nothing
+// guarantees `core/style.js` has injected `#respec-mainstyle` before this module is
+// evaluated. Excluding by id is correct whichever order they happen to run in.
+const RESPEC_STYLE_IDS = ["respec-mainstyle", "baseline-stylesheet"];
+const authorStyles = new Set(
+  [...document.querySelectorAll("head style")].filter(
+    el => !RESPEC_STYLE_IDS.includes(el.id)
+  )
+);
+
 /**
  * @param {URL|string} linkURL
  * @returns {(exportDoc: Document) => void}
@@ -98,6 +111,63 @@ function styleMover(linkURL) {
       exportDoc.querySelector("head")?.append(w3cStyle);
     }
   };
+}
+
+/**
+ * Remove every `@media (prefers-color-scheme: dark)` block from a stylesheet.
+ *
+ * Brace counting rather than Bikeshed's left-margin regex (`manager.py:250-270`),
+ * because ReSpec's stylesheets reach the page from a minified bundle: there is no
+ * newline to anchor to, the whole sheet is one line. Counts braces from the block's
+ * opening one, so it works on minified and readable CSS alike.
+ *
+ * Known limit: a `{` or `}` inside a string or comment would miscount. None of
+ * ReSpec's stylesheets contain one, and this only ever runs over ReSpec's own.
+ *
+ * @param {string} css
+ * @returns {string}
+ */
+export function stripDarkMediaBlocks(css) {
+  const opener = /@media[^{]*prefers-color-scheme\s*:\s*dark[^{]*\{/gi;
+  let out = "";
+  let copiedTo = 0;
+  let match;
+  while ((match = opener.exec(css)) !== null) {
+    let depth = 1;
+    let i = opener.lastIndex;
+    while (i < css.length && depth > 0) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") depth--;
+      i++;
+    }
+    out += css.slice(copiedTo, match.index);
+    copiedTo = i;
+    opener.lastIndex = i;
+  }
+  return copiedTo === 0 ? css : out + css.slice(copiedTo);
+}
+
+/**
+ * Strips ReSpec's own dark styles, the way Bikeshed's `removeInlineDarkStyles()`
+ * strips its own, once the editor has turned dark mode off.
+ *
+ * Skip this and the browser paints a light page with dark ReSpec components for
+ * anyone whose operating system prefers dark: dark CDDL tokens, a dark `.assert`
+ * block, dark baseline pills. Nothing else can prevent that. Those blocks are
+ * media queries, and neither CSS nor a meta tag can stop a media query matching,
+ * which I measured in Safari 27, Chrome 151 and Firefox 153. Deleting the text is
+ * the only lever ReSpec has.
+ *
+ * This runs once on `end-all`. That is late enough because every module injects
+ * its stylesheet from `run()` or `prepare()`, and no module injects one at or
+ * after `end-all`.
+ */
+function stripReSpecDarkStyles() {
+  for (const style of document.querySelectorAll("head style")) {
+    if (authorStyles.has(style)) continue;
+    const stripped = stripDarkMediaBlocks(style.textContent);
+    if (stripped !== style.textContent) style.textContent = stripped;
+  }
 }
 
 /**
@@ -144,6 +214,31 @@ export function run(conf) {
   );
   // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
   sub("beforesave", styleMover(finalStyleURL));
+
+  // The editor has turned dark mode off, so do what Bikeshed's `Dark Mode: off`
+  // does: emit no `color-scheme` meta and no dark stylesheet link
+  // (`boilerplate.py:1293` returns before it writes either), and strip dark blocks
+  // out of our own styles. Omitting the link is the whole mechanism, because
+  // fixup.js only builds the theme toggle when it finds that link.
+  //
+  // Strictly `=== false`. Absent is the default and `undefined` is falsy, so a
+  // general falsy test would have disabled dark mode on every spec that never set
+  // the option. Returning here also matters: the code below reads
+  // `colorScheme.content`, which would throw once the meta is no longer injected.
+  if (conf.darkMode === false) {
+    // `createResourceHints()` above adds the preload hint at import time, before
+    // any config exists, so this is the only place that can remove it. Worth doing:
+    // a spec whose editor turned dark mode off should not fetch a stylesheet it
+    // will never apply, and anyone searching for `link[href$="dark.css"]` would
+    // still find the leftover hint.
+    document
+      .querySelector(
+        `head link[rel~="preload"][href="${getStyleUrl("dark.css")}"]`
+      )
+      ?.remove();
+    sub("end-all", stripReSpecDarkStyles, { once: true });
+    return;
+  }
 
   // Add color scheme meta tag and style
   /** @type {HTMLMetaElement | null} */

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -146,9 +146,6 @@ export function run(conf) {
   // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
   sub("beforesave", styleMover(finalStyleURL));
 
-  // Keep this `=== false` and keep the early return. A falsy test would turn dark mode off on
-  // every spec that never set the option, and the code below reads `colorScheme.content`,
-  // which throws once the meta is no longer injected.
   if (conf.darkMode === false) {
     disableDarkStyles();
     // Without this the page still downloads dark.css, which it will never apply.

--- a/tests/spec/core/author-dark-style-late.html
+++ b/tests/spec/core/author-dark-style-late.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <meta charset="utf-8" />
+  <title>Simple Spec</title>
+  <script class="remove">
+    function addAuthorDarkStyle(id) {
+      const style = document.createElement("style");
+      if (id) style.id = id;
+      else style.dataset.authorNoId = "";
+      style.textContent =
+        "@media (prefers-color-scheme: dark) { .author-thing { background: rebeccapurple; } }";
+      document.head.append(style);
+    }
+    var respecConfig = {
+      specStatus: "base",
+      shortName: "basics",
+      darkMode: false,
+      preProcess: [
+        () => addAuthorDarkStyle("author-preprocess-style"),
+        () => addAuthorDarkStyle(""),
+      ],
+      postProcess: [() => addAuthorDarkStyle("author-postprocess-style")],
+    };
+  </script>
+  <section id="abstract">
+    <p>Basic doc</p>
+  </section>
+  <section id="sotd">
+    <p>
+      Adds author stylesheets carrying a dark media query from preProcess and
+      from postProcess, one of them with no id at all.
+    </p>
+  </section>
+</html>

--- a/tests/spec/core/author-dark-style.html
+++ b/tests/spec/core/author-dark-style.html
@@ -1,27 +1,28 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<meta charset='utf-8'/>
-<title>Simple Spec</title>
-<style id="author-head-style">
-  /* An author's own dark styles, in the head, which is where real specs put them.
+  <meta charset="utf-8" />
+  <title>Simple Spec</title>
+  <style id="author-head-style">
+    /* An author's own dark styles, in the head, which is where real specs put them.
      ReSpec's darkMode:false strip must leave this alone: it only owns its own CSS. */
-  @media (prefers-color-scheme: dark) {
-    .author-thing {
-      background: rebeccapurple;
+    @media (prefers-color-scheme: dark) {
+      .author-thing {
+        background: rebeccapurple;
+      }
     }
-  }
-</style>
-<script class='remove'>
-var respecConfig = {
-  specStatus: "base",
-  shortName: "basics",
-};
-</script>
-<section id='abstract'>
-  <p>Basic doc</p>
-</section>
-<section id='sotd'>
-  <p>
-    Carries an author stylesheet in the head, with a dark media query in it.
-  </p>
-</section>
+  </style>
+  <script class="remove">
+    var respecConfig = {
+      specStatus: "base",
+      shortName: "basics",
+    };
+  </script>
+  <section id="abstract">
+    <p>Basic doc</p>
+  </section>
+  <section id="sotd">
+    <p>
+      Carries an author stylesheet in the head, with a dark media query in it.
+    </p>
+  </section>
+</html>

--- a/tests/spec/core/author-dark-style.html
+++ b/tests/spec/core/author-dark-style.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<meta charset='utf-8'/>
+<title>Simple Spec</title>
+<style id="author-head-style">
+  /* An author's own dark styles, in the head, which is where real specs put them.
+     ReSpec's darkMode:false strip must leave this alone: it only owns its own CSS. */
+  @media (prefers-color-scheme: dark) {
+    .author-thing {
+      background: rebeccapurple;
+    }
+  }
+</style>
+<script class='remove'>
+var respecConfig = {
+  specStatus: "base",
+  shortName: "basics",
+};
+</script>
+<section id='abstract'>
+  <p>Basic doc</p>
+</section>
+<section id='sotd'>
+  <p>
+    Carries an author stylesheet in the head, with a dark media query in it.
+  </p>
+</section>

--- a/tests/spec/w3c/dark-mode-opt-out-spec.js
+++ b/tests/spec/w3c/dark-mode-opt-out-spec.js
@@ -1,0 +1,214 @@
+"use strict";
+// Second and last edit to the generated tests: `getExportedDoc` was imported and
+// never used (the export assertions go through `respec.toHTML()` instead), and an
+// unused import fails lint. No assertion changed.
+import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
+import { seedGroupCache } from "../respec-cache-helper.js";
+
+const DARK_CSS = "https://www.w3.org/StyleSheets/TR/2021/dark.css";
+// Gemini wrote this as the literal string "@media (prefers-color-scheme: dark)".
+// The build minifies the space away, so the bundle karma loads contains
+// "prefers-color-scheme:dark" and that literal appeared ZERO times: every
+// `not.toMatch(MEDIA_DARK)` below passed with no implementation at all. Widened to
+// a whitespace-tolerant pattern so the assertions can actually fail. This is the only
+// edit made to the generated tests, and it makes them stricter, not weaker.
+const MEDIA_DARK = /@media\s*\([^)]*prefers-color-scheme\s*:\s*dark/;
+
+describe("W3C - Style - darkMode opt-out", () => {
+  afterAll(flushIframes);
+  beforeAll(seedGroupCache);
+
+  it("leaves dark mode ON by default, injecting meta and appending dark stylesheet", async () => {
+    const ops = makeStandardOps({ specStatus: "ED", group: "webapps" });
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
+      "light"
+    );
+    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
+  });
+
+  it("leaves dark mode ON when darkMode is the string 'false'", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: "false",
+    });
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
+      "light"
+    );
+    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
+  });
+
+  it("leaves dark mode ON when darkMode is null", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: null,
+    });
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
+  });
+
+  it("leaves dark mode ON when darkMode is 0", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: 0,
+    });
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
+  });
+
+  it("leaves dark mode ON when darkMode is true", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: true,
+    });
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
+  });
+
+  it("does not append the dark stylesheet link when darkMode is strictly false", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: false,
+    });
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeNull();
+  });
+
+  it("does not subscribe export handlers when false, leaving exported doc without dark link", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: false,
+    });
+    const doc = await makeRSDoc(ops);
+    const exported = await doc.respec.toHTML();
+    expect(exported).not.toContain(DARK_CSS);
+  });
+
+  it("includes the dark link in the exported doc when darkMode is ON", async () => {
+    const ops = makeStandardOps({ specStatus: "ED", group: "webapps" });
+    const doc = await makeRSDoc(ops);
+    const exported = await doc.respec.toHTML();
+    expect(exported).toContain(DARK_CSS);
+  });
+
+  it("does not inject <meta name='color-scheme'> when darkMode is strictly false", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: false,
+    });
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector("meta[name='color-scheme']")).toBeNull();
+  });
+
+  it("preserves author-supplied <meta name='color-scheme'> when darkMode is false", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: false,
+    });
+    const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
+    expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
+      "dark light"
+    );
+  });
+
+  it("preserves author-supplied <meta name='color-scheme'> when darkMode is ON", async () => {
+    const ops = makeStandardOps({ specStatus: "ED", group: "webapps" });
+    const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
+    expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
+      "dark light"
+    );
+  });
+
+  it("strips @media dark blocks from ReSpec's main styles when darkMode is false", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: false,
+    });
+    const doc = await makeRSDoc(ops);
+    const headStyleText = [...doc.querySelectorAll("head style")]
+      .map(s => s.textContent)
+      .join("");
+    expect(headStyleText).not.toMatch(MEDIA_DARK);
+    expect(doc.getElementById("respec-mainstyle")).toBeTruthy();
+  });
+
+  it("strips @media dark blocks from triggered component styles when darkMode is false", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: false,
+    });
+    ops.body = `
+      <ul><li class="assert"></li></ul>
+      <pre class="cddl"></pre>
+      <pre class="js"></pre>
+    `;
+    const doc = await makeRSDoc(ops);
+    const headStyleText = [...doc.querySelectorAll("head style")]
+      .map(s => s.textContent)
+      .join("");
+    expect(headStyleText).not.toMatch(MEDIA_DARK);
+  });
+
+  it("strips @media dark blocks from config-triggered styles when darkMode is false", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: false,
+      highlightVars: true,
+    });
+    const doc = await makeRSDoc(ops);
+    const headStyleText = [...doc.querySelectorAll("head style")]
+      .map(s => s.textContent)
+      .join("");
+    expect(headStyleText).not.toMatch(MEDIA_DARK);
+  });
+
+  it("preserves author-written @media dark blocks in the body when darkMode is false", async () => {
+    const ops = makeStandardOps({
+      specStatus: "ED",
+      group: "webapps",
+      darkMode: false,
+    });
+    ops.body = `<style id="author-style">@media (prefers-color-scheme: dark) { body { color: red; } }</style>`;
+    const doc = await makeRSDoc(ops);
+    const authorStyle = doc.getElementById("author-style").textContent;
+    expect(authorStyle).toMatch(MEDIA_DARK);
+
+    // Ensure ReSpec's own are still stripped
+    const headStyleText = [...doc.querySelectorAll("head style")]
+      .map(s => s.textContent)
+      .join("");
+    expect(headStyleText).not.toMatch(MEDIA_DARK);
+  });
+  // Added by me, not Gemini, because my brief to it was wrong: I told it to put the
+  // author's <style> in the body, and the strip only walks `head style`, so its
+  // author-preservation test could not fail. Mutation-checked: deleting the
+  // `authorStyles.has(style)` guard left all 15 of its tests green. Real specs put
+  // their CSS in the head, and the spec harness has no head option, so this needs a
+  // fixture.
+  it("leaves an author stylesheet in the head alone when darkMode is false", async () => {
+    const ops = makeStandardOps({ darkMode: false });
+    const doc = await makeRSDoc(ops, "spec/core/author-dark-style.html");
+    const authorStyle = doc.getElementById("author-head-style");
+    expect(authorStyle).toBeTruthy();
+    expect(authorStyle.textContent).toMatch(MEDIA_DARK);
+    expect(authorStyle.textContent).toContain("rebeccapurple");
+    // ReSpec's own are still stripped in the same document.
+    const respecStyles = [...doc.querySelectorAll("head style")]
+      .filter(s => s.id !== "author-head-style")
+      .map(s => s.textContent)
+      .join("");
+    expect(respecStyles).not.toMatch(MEDIA_DARK);
+  });
+});

--- a/tests/spec/w3c/dark-mode-opt-out-spec.js
+++ b/tests/spec/w3c/dark-mode-opt-out-spec.js
@@ -1,86 +1,59 @@
 "use strict";
-// Second and last edit to the generated tests: `getExportedDoc` was imported and
-// never used (the export assertions go through `respec.toHTML()` instead), and an
-// unused import fails lint. No assertion changed.
 import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
 import { seedGroupCache } from "../respec-cache-helper.js";
 
 const DARK_CSS = "https://www.w3.org/StyleSheets/TR/2021/dark.css";
-// Gemini wrote this as the literal string "@media (prefers-color-scheme: dark)".
-// The build minifies the space away, so the bundle karma loads contains
-// "prefers-color-scheme:dark" and that literal appeared ZERO times: every
-// `not.toMatch(MEDIA_DARK)` below passed with no implementation at all. Widened to
-// a whitespace-tolerant pattern so the assertions can actually fail. This is the only
-// edit made to the generated tests, and it makes them stricter, not weaker.
+// Filter by `rel`, or the module's `rel="preload"` hint for the same URL satisfies the
+// assertion on its own.
+const DARK_SHEET = `link[rel~="stylesheet"][href='${DARK_CSS}']`;
+// Whitespace-tolerant: karma loads the minified bundle, where the space in
+// `(prefers-color-scheme: dark)` is gone.
 const MEDIA_DARK = /@media\s*\([^)]*prefers-color-scheme\s*:\s*dark/;
+// Assert on ReSpec's own sheet, not the joined total of `head style`. The strip skips the
+// author `<style>` the harness leaves there, so a total stays non-empty regardless.
+const respecStyleText = doc =>
+  doc.getElementById("respec-mainstyle").textContent;
+// Only a strict `=== false` turns dark mode off. `undefined` arrives as an absent key,
+// because JSON.stringify drops it.
+const DARK_MODE_STAYS_ON = [
+  ["absent", undefined],
+  ["the string 'false'", "false"],
+  ["null", null],
+  ["0", 0],
+  ["true", true],
+];
 
 describe("W3C - Style - darkMode opt-out", () => {
   afterAll(flushIframes);
   beforeAll(seedGroupCache);
 
-  it("leaves dark mode ON by default, injecting meta and appending dark stylesheet", async () => {
-    const ops = makeStandardOps({ specStatus: "ED", group: "webapps" });
-    const doc = await makeRSDoc(ops);
-    expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
-      "light"
-    );
-    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
-  });
-
-  it("leaves dark mode ON when darkMode is the string 'false'", async () => {
-    const ops = makeStandardOps({
-      specStatus: "ED",
-      group: "webapps",
-      darkMode: "false",
+  for (const [label, darkMode] of DARK_MODE_STAYS_ON) {
+    it(`leaves dark mode ON when darkMode is ${label}`, async () => {
+      const ops = makeStandardOps({
+        specStatus: "ED",
+        group: "webapps",
+        darkMode,
+      });
+      const doc = await makeRSDoc(ops);
+      expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
+        "light"
+      );
+      expect(doc.querySelector(DARK_SHEET)).toBeTruthy();
     });
-    const doc = await makeRSDoc(ops);
-    expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
-      "light"
-    );
-    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
-  });
+  }
 
-  it("leaves dark mode ON when darkMode is null", async () => {
-    const ops = makeStandardOps({
-      specStatus: "ED",
-      group: "webapps",
-      darkMode: null,
-    });
-    const doc = await makeRSDoc(ops);
-    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
-  });
-
-  it("leaves dark mode ON when darkMode is 0", async () => {
-    const ops = makeStandardOps({
-      specStatus: "ED",
-      group: "webapps",
-      darkMode: 0,
-    });
-    const doc = await makeRSDoc(ops);
-    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
-  });
-
-  it("leaves dark mode ON when darkMode is true", async () => {
-    const ops = makeStandardOps({
-      specStatus: "ED",
-      group: "webapps",
-      darkMode: true,
-    });
-    const doc = await makeRSDoc(ops);
-    expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeTruthy();
-  });
-
-  it("does not append the dark stylesheet link when darkMode is strictly false", async () => {
+  it("removes both the dark stylesheet and its preload hint when darkMode is strictly false", async () => {
     const ops = makeStandardOps({
       specStatus: "ED",
       group: "webapps",
       darkMode: false,
     });
     const doc = await makeRSDoc(ops);
+    // Unfiltered by `rel` on purpose, so this also fails if the preload hint survives.
     expect(doc.querySelector(`link[href='${DARK_CSS}']`)).toBeNull();
   });
 
-  it("does not subscribe export handlers when false, leaving exported doc without dark link", async () => {
+  it("omits the dark stylesheet from the exported doc when darkMode is false", async () => {
     const ops = makeStandardOps({
       specStatus: "ED",
       group: "webapps",
@@ -108,7 +81,7 @@ describe("W3C - Style - darkMode opt-out", () => {
     expect(doc.querySelector("meta[name='color-scheme']")).toBeNull();
   });
 
-  it("preserves author-supplied <meta name='color-scheme'> when darkMode is false", async () => {
+  it("keeps an author's color-scheme meta and still skips dark mode when darkMode is false", async () => {
     const ops = makeStandardOps({
       specStatus: "ED",
       group: "webapps",
@@ -118,14 +91,26 @@ describe("W3C - Style - darkMode opt-out", () => {
     expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
       "dark light"
     );
+    // The opt-out wins over the author's `dark` preference.
+    expect(doc.querySelector(DARK_SHEET)).toBeNull();
   });
 
-  it("preserves author-supplied <meta name='color-scheme'> when darkMode is ON", async () => {
+  it("reads dark from an author's color-scheme meta and enables the dark stylesheet", async () => {
     const ops = makeStandardOps({ specStatus: "ED", group: "webapps" });
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
     expect(doc.querySelector("meta[name='color-scheme']")?.content).toBe(
       "dark light"
     );
+    // Assert on the export, not the live document: fixup.js sets `media = ""` on the
+    // live link. These two attributes are the only trace that the module read the meta.
+    const exported = await doc.respec.toHTML();
+    const darkSheet = new DOMParser()
+      .parseFromString(exported, "text/html")
+      .querySelector(DARK_SHEET);
+    expect(darkSheet.getAttribute("media")).toBe(
+      "(prefers-color-scheme: dark)"
+    );
+    expect(darkSheet.hasAttribute("disabled")).toBe(false);
   });
 
   it("strips @media dark blocks from ReSpec's main styles when darkMode is false", async () => {
@@ -139,7 +124,7 @@ describe("W3C - Style - darkMode opt-out", () => {
       .map(s => s.textContent)
       .join("");
     expect(headStyleText).not.toMatch(MEDIA_DARK);
-    expect(doc.getElementById("respec-mainstyle")).toBeTruthy();
+    expect(respecStyleText(doc).length).toBeGreaterThan(0);
   });
 
   it("strips @media dark blocks from triggered component styles when darkMode is false", async () => {
@@ -158,6 +143,7 @@ describe("W3C - Style - darkMode opt-out", () => {
       .map(s => s.textContent)
       .join("");
     expect(headStyleText).not.toMatch(MEDIA_DARK);
+    expect(respecStyleText(doc).length).toBeGreaterThan(0);
   });
 
   it("strips @media dark blocks from config-triggered styles when darkMode is false", async () => {
@@ -172,31 +158,11 @@ describe("W3C - Style - darkMode opt-out", () => {
       .map(s => s.textContent)
       .join("");
     expect(headStyleText).not.toMatch(MEDIA_DARK);
+    expect(respecStyleText(doc).length).toBeGreaterThan(0);
   });
 
-  it("preserves author-written @media dark blocks in the body when darkMode is false", async () => {
-    const ops = makeStandardOps({
-      specStatus: "ED",
-      group: "webapps",
-      darkMode: false,
-    });
-    ops.body = `<style id="author-style">@media (prefers-color-scheme: dark) { body { color: red; } }</style>`;
-    const doc = await makeRSDoc(ops);
-    const authorStyle = doc.getElementById("author-style").textContent;
-    expect(authorStyle).toMatch(MEDIA_DARK);
-
-    // Ensure ReSpec's own are still stripped
-    const headStyleText = [...doc.querySelectorAll("head style")]
-      .map(s => s.textContent)
-      .join("");
-    expect(headStyleText).not.toMatch(MEDIA_DARK);
-  });
-  // Added by me, not Gemini, because my brief to it was wrong: I told it to put the
-  // author's <style> in the body, and the strip only walks `head style`, so its
-  // author-preservation test could not fail. Mutation-checked: deleting the
-  // `authorStyles.has(style)` guard left all 15 of its tests green. Real specs put
-  // their CSS in the head, and the spec harness has no head option, so this needs a
-  // fixture.
+  // Needs a fixture: the strip only walks `head style`, so a body `<style>` cannot fail,
+  // and the harness offers no head option.
   it("leaves an author stylesheet in the head alone when darkMode is false", async () => {
     const ops = makeStandardOps({ darkMode: false });
     const doc = await makeRSDoc(ops, "spec/core/author-dark-style.html");
@@ -207,6 +173,31 @@ describe("W3C - Style - darkMode opt-out", () => {
     // ReSpec's own are still stripped in the same document.
     const respecStyles = [...doc.querySelectorAll("head style")]
       .filter(s => s.id !== "author-head-style")
+      .map(s => s.textContent)
+      .join("");
+    expect(respecStyles).not.toMatch(MEDIA_DARK);
+  });
+
+  // Capturing author styles at import time strips the preProcess one; running the strip
+  // on `end-all` strips the postProcess one.
+  it("leaves author stylesheets added in preProcess and postProcess alone when darkMode is false", async () => {
+    const ops = makeStandardOps();
+    ops.config = null; // the fixture carries its own config, including the callbacks
+    const doc = await makeRSDoc(ops, "spec/core/author-dark-style-late.html");
+    const ids = ["author-preprocess-style", "author-postprocess-style"];
+    // The third carries no id at all, which no allowlist could ever have covered.
+    const authorStyles = [
+      ...ids.map(id => doc.getElementById(id)),
+      doc.querySelector("head style[data-author-no-id]"),
+    ];
+    for (const authorStyle of authorStyles) {
+      expect(authorStyle).toBeTruthy();
+      expect(authorStyle.textContent).toMatch(MEDIA_DARK);
+      expect(authorStyle.textContent).toContain("rebeccapurple");
+    }
+    // ReSpec's own are still stripped in the same document.
+    const respecStyles = [...doc.querySelectorAll("head style")]
+      .filter(s => !authorStyles.includes(s))
       .map(s => s.textContent)
       .join("");
     expect(respecStyles).not.toMatch(MEDIA_DARK);

--- a/tests/unit/core/insert-style-spec.js
+++ b/tests/unit/core/insert-style-spec.js
@@ -1,6 +1,10 @@
 "use strict";
 
-import { insertStyle, stripDarkMediaBlocks } from "/src/core/insert-style.js";
+import {
+  disableDarkStyles,
+  insertStyle,
+  stripDarkMediaBlocks,
+} from "/src/core/insert-style.js";
 
 describe("Core - insertStyle", () => {
   /** @type {Element[]} */
@@ -39,6 +43,7 @@ describe("Core - insertStyle", () => {
   it("appends to the head when the anchor is null", () => {
     const style = insert("a{color:red}", { before: null });
     expect(style.parentNode).toBe(document.head);
+    expect(document.head.lastElementChild).toBe(style);
   });
 
   // Callers pass an unscoped `document.querySelector("link")`, which can return a node
@@ -167,5 +172,47 @@ describe("Core - stripDarkMediaBlocks", () => {
         "@media (prefers-color-scheme: dark) { a::after { content: '}'; } }"
       )
     ).toBe(" }");
+  });
+});
+
+describe("Core - stripDarkMediaBlocks, destructive input", () => {
+  // Each of these once deleted valid CSS. They now leave the sheet alone, because the end of
+  // an unbalanced block is unknown and guessing at it loses rules silently.
+  it("leaves the sheet alone when a dark block never closes", () => {
+    const css =
+      "a { color: red; } @media (prefers-color-scheme: dark) { b { color: white; } c { color: blue; }";
+    expect(stripDarkMediaBlocks(css)).toBe(css);
+  });
+
+  it("leaves the sheet alone when a comment holds the opener", () => {
+    const css = "/* @media (prefers-color-scheme: dark) { */ body{color:red}";
+    expect(stripDarkMediaBlocks(css)).toBe(css);
+  });
+
+  it("keeps `not (prefers-color-scheme: dark)`, which forces a page light", () => {
+    const css =
+      "@media not (prefers-color-scheme: dark){body{background:#fff}}";
+    expect(stripDarkMediaBlocks(css)).toBe(css);
+  });
+});
+
+// `disableDarkStyles` sets a module flag that lives for the whole realm and nothing resets it,
+// and jasmine runs specs in random order, so the before and after states cannot be split into
+// two specs: whichever ran second would find the flag already set. One spec walks the whole
+// lifecycle instead. Keep dark CSS out of every other spec in this file for the same reason.
+describe("Core - disableDarkStyles", () => {
+  it("strips dark rules from stylesheets already inserted, and from later ones", () => {
+    const DARK = "@media (prefers-color-scheme: dark){.x{color:#fff}}";
+    const existing = insertStyle(`.x{color:red}${DARK}`);
+    expect(existing.textContent).toContain("prefers-color-scheme");
+
+    disableDarkStyles();
+    expect(existing.textContent).toBe(".x{color:red}");
+
+    const later = insertStyle(`.y{color:green}${DARK}`);
+    expect(later.textContent).toBe(".y{color:green}");
+
+    existing.remove();
+    later.remove();
   });
 });

--- a/tests/unit/core/insert-style-spec.js
+++ b/tests/unit/core/insert-style-spec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { insertStyle } from "/src/core/insert-style.js";
+import { insertStyle, stripDarkMediaBlocks } from "/src/core/insert-style.js";
 
 describe("Core - insertStyle", () => {
   /** @type {Element[]} */
@@ -73,5 +73,99 @@ describe("Core - insertStyle", () => {
     });
     expect(style.id).toBe("probe-id");
     expect(style.className).toBe("probe");
+  });
+});
+
+describe("Core - stripDarkMediaBlocks", () => {
+  it("returns CSS with no dark block unchanged", () => {
+    expect(stripDarkMediaBlocks("")).toBe("");
+    expect(stripDarkMediaBlocks("body { color: black; }")).toBe(
+      "body { color: black; }"
+    );
+  });
+
+  it("removes a dark block", () => {
+    expect(
+      stripDarkMediaBlocks(
+        "@media (prefers-color-scheme: dark) { body { color: white; } }"
+      )
+    ).toBe("");
+  });
+
+  it("leaves other media queries alone", () => {
+    const print = "@media print { body { color: black; } }";
+    expect(stripDarkMediaBlocks(print)).toBe(print);
+    const light = "@media (prefers-color-scheme: light) { a{} }";
+    expect(stripDarkMediaBlocks(light)).toBe(light);
+  });
+
+  it("handles minified CSS, where the whole sheet is one line", () => {
+    expect(
+      stripDarkMediaBlocks(
+        "a{}@media(prefers-color-scheme:dark){b{color:#fff;}}c{}"
+      )
+    ).toBe("a{}c{}");
+  });
+
+  it("counts nested braces rather than stopping at the first closer", () => {
+    expect(
+      stripDarkMediaBlocks(
+        "@media (prefers-color-scheme: dark) { @supports (display: grid) { a{} } }"
+      )
+    ).toBe("");
+  });
+
+  it("removes every dark block, not just the first", () => {
+    expect(
+      stripDarkMediaBlocks(
+        "@media (prefers-color-scheme: dark){a{}} @media (prefers-color-scheme: dark){b{}}"
+      )
+    ).toBe(" ");
+  });
+
+  it("matches a dark condition combined with others", () => {
+    expect(
+      stripDarkMediaBlocks(
+        "@media screen and (prefers-color-scheme: dark) { a{} }"
+      )
+    ).toBe("");
+    expect(
+      stripDarkMediaBlocks("@media print, (prefers-color-scheme: dark) { a{} }")
+    ).toBe("");
+  });
+
+  it("matches across newlines inside the condition", () => {
+    expect(
+      stripDarkMediaBlocks("@media\n(prefers-color-scheme:\ndark\n) { a{} }")
+    ).toBe("");
+  });
+
+  it("leaves everything outside the block byte-identical", () => {
+    expect(
+      stripDarkMediaBlocks(
+        "a{} \n@media (prefers-color-scheme: dark) { b{} }\n c{}"
+      )
+    ).toBe("a{} \n\n c{}");
+  });
+
+  // The two cases below pin a KNOWN limitation, not desired behaviour. Braces and at-rules
+  // inside a CSS string confuse the scan. Acceptable because only ReSpec's own stylesheets
+  // reach this function, and none of them contain one; `insertStyle` is what guarantees an
+  // author's CSS never gets here. If a fix ever lands, these two should fail and be
+  // rewritten to the correct expectation.
+  it("known limitation: an at-rule inside a string is treated as real", () => {
+    expect(
+      stripDarkMediaBlocks(
+        "body { content: '@media (prefers-color-scheme: dark) {}'; }"
+      )
+    ).toBe("body { content: ''; }");
+  });
+
+  it("known limitation: a closing brace inside a string ends the block early", () => {
+    expect(
+      stripDarkMediaBlocks(
+        "@media (prefers-color-scheme: dark) { a::after { content: '}'; } }"
+      )
+    ).toBe(" }");
   });
 });

--- a/tests/unit/core/insert-style-spec.js
+++ b/tests/unit/core/insert-style-spec.js
@@ -47,8 +47,7 @@ describe("Core - insertStyle", () => {
   });
 
   // Callers pass an unscoped `document.querySelector("link")`, which can return a node
-  // outside the head. Inserting relative to the anchor rather than through `head` put
-  // ReSpec's CSS in the body.
+  // outside the head.
   it("never inserts outside the head, whatever the anchor's parent is", () => {
     const stray = document.createElement("link");
     document.body.appendChild(stray);
@@ -82,124 +81,105 @@ describe("Core - insertStyle", () => {
 });
 
 describe("Core - stripDarkMediaBlocks", () => {
+  // Assert on the rules, not the text: the parser normalizes what it re-serializes, so a
+  // string comparison here would be testing the serializer.
+
+  /** @param {string} css @returns {string[]} the condition of each surviving `@media` */
+  function conditions(css) {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(stripDarkMediaBlocks(css));
+    return [...sheet.cssRules]
+      .filter(r => r instanceof CSSMediaRule)
+      .map(r => r.conditionText);
+  }
+
+  /** @param {string} css @returns {string[]} the selector of each surviving top-level rule */
+  function selectors(css) {
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(stripDarkMediaBlocks(css));
+    return [...sheet.cssRules]
+      .filter(r => r instanceof CSSStyleRule)
+      .map(r => r.selectorText);
+  }
+
   it("returns CSS with no dark block unchanged", () => {
     expect(stripDarkMediaBlocks("")).toBe("");
-    expect(stripDarkMediaBlocks("body { color: black; }")).toBe(
-      "body { color: black; }"
-    );
+    expect(selectors("body { color: black; }")).toEqual(["body"]);
   });
 
-  it("removes a dark block", () => {
-    expect(
-      stripDarkMediaBlocks(
-        "@media (prefers-color-scheme: dark) { body { color: white; } }"
-      )
-    ).toBe("");
+  it("removes a dark block and keeps everything else", () => {
+    const css =
+      "a{color:red}@media (prefers-color-scheme: dark){b{color:#fff}}c{color:blue}";
+    expect(conditions(css)).toEqual([]);
+    expect(selectors(css)).toEqual(["a", "c"]);
   });
 
   it("leaves other media queries alone", () => {
-    const print = "@media print { body { color: black; } }";
-    expect(stripDarkMediaBlocks(print)).toBe(print);
-    const light = "@media (prefers-color-scheme: light) { a{} }";
-    expect(stripDarkMediaBlocks(light)).toBe(light);
+    expect(conditions("@media print { body { color: black; } }")).toEqual([
+      "print",
+    ]);
+    expect(
+      conditions("@media (prefers-color-scheme: light) { a{color:red} }")
+    ).toEqual(["(prefers-color-scheme: light)"]);
   });
 
   it("handles minified CSS, where the whole sheet is one line", () => {
-    expect(
-      stripDarkMediaBlocks(
-        "a{}@media(prefers-color-scheme:dark){b{color:#fff;}}c{}"
-      )
-    ).toBe("a{}c{}");
+    const css =
+      "a{color:red}@media(prefers-color-scheme:dark){b{color:#fff}}c{color:blue}";
+    expect(selectors(css)).toEqual(["a", "c"]);
   });
 
-  it("counts nested braces rather than stopping at the first closer", () => {
-    expect(
-      stripDarkMediaBlocks(
-        "@media (prefers-color-scheme: dark) { @supports (display: grid) { a{} } }"
-      )
-    ).toBe("");
+  it("removes a nested dark block whole, braces and all", () => {
+    const css =
+      "@media (prefers-color-scheme: dark) { @supports (display: grid) { a{color:red} } }";
+    expect(stripDarkMediaBlocks(css)).toBe("");
   });
 
   it("removes every dark block, not just the first", () => {
-    expect(
-      stripDarkMediaBlocks(
-        "@media (prefers-color-scheme: dark){a{}} @media (prefers-color-scheme: dark){b{}}"
-      )
-    ).toBe(" ");
-  });
-
-  it("matches a dark condition combined with others", () => {
-    expect(
-      stripDarkMediaBlocks(
-        "@media screen and (prefers-color-scheme: dark) { a{} }"
-      )
-    ).toBe("");
-    expect(
-      stripDarkMediaBlocks("@media print, (prefers-color-scheme: dark) { a{} }")
-    ).toBe("");
-  });
-
-  it("matches across newlines inside the condition", () => {
-    expect(
-      stripDarkMediaBlocks("@media\n(prefers-color-scheme:\ndark\n) { a{} }")
-    ).toBe("");
-  });
-
-  it("leaves everything outside the block byte-identical", () => {
-    expect(
-      stripDarkMediaBlocks(
-        "a{} \n@media (prefers-color-scheme: dark) { b{} }\n c{}"
-      )
-    ).toBe("a{} \n\n c{}");
-  });
-
-  // The two cases below pin a KNOWN limitation, not desired behaviour. Braces and at-rules
-  // inside a CSS string confuse the scan. Acceptable because only ReSpec's own stylesheets
-  // reach this function, and none of them contain one; `insertStyle` is what guarantees an
-  // author's CSS never gets here. If a fix ever lands, these two should fail and be
-  // rewritten to the correct expectation.
-  it("known limitation: an at-rule inside a string is treated as real", () => {
-    expect(
-      stripDarkMediaBlocks(
-        "body { content: '@media (prefers-color-scheme: dark) {}'; }"
-      )
-    ).toBe("body { content: ''; }");
-  });
-
-  it("known limitation: a closing brace inside a string ends the block early", () => {
-    expect(
-      stripDarkMediaBlocks(
-        "@media (prefers-color-scheme: dark) { a::after { content: '}'; } }"
-      )
-    ).toBe(" }");
-  });
-});
-
-describe("Core - stripDarkMediaBlocks, destructive input", () => {
-  // Each of these once deleted valid CSS. They now leave the sheet alone, because the end of
-  // an unbalanced block is unknown and guessing at it loses rules silently.
-  it("leaves the sheet alone when a dark block never closes", () => {
     const css =
-      "a { color: red; } @media (prefers-color-scheme: dark) { b { color: white; } c { color: blue; }";
-    expect(stripDarkMediaBlocks(css)).toBe(css);
+      "@media (prefers-color-scheme: dark){a{color:red}} @media (prefers-color-scheme: dark){b{color:blue}}";
+    expect(conditions(css)).toEqual([]);
   });
 
-  it("leaves the sheet alone when a comment holds the opener", () => {
-    const css = "/* @media (prefers-color-scheme: dark) { */ body{color:red}";
-    expect(stripDarkMediaBlocks(css)).toBe(css);
+  it("removes a dark condition combined with others", () => {
+    expect(
+      conditions(
+        "@media screen and (prefers-color-scheme: dark) { a{color:red} }"
+      )
+    ).toEqual([]);
+    expect(
+      conditions("@media print, (prefers-color-scheme: dark) { a{color:red} }")
+    ).toEqual([]);
   });
 
   it("keeps `not (prefers-color-scheme: dark)`, which forces a page light", () => {
+    expect(
+      conditions(
+        "@media not (prefers-color-scheme: dark){body{background:#fff}}"
+      )
+    ).toEqual(["not (prefers-color-scheme: dark)"]);
+  });
+
+  it("keeps a rule holding a brace in a string", () => {
     const css =
-      "@media not (prefers-color-scheme: dark){body{background:#fff}}";
-    expect(stripDarkMediaBlocks(css)).toBe(css);
+      "@media (prefers-color-scheme: dark){a::after{content:'}'}}c{color:blue}";
+    expect(selectors(css)).toEqual(["c"]);
+  });
+
+  it("keeps a rule whose declaration merely mentions a dark at-rule", () => {
+    const css = "body { content: '@media (prefers-color-scheme: dark) {}'; }";
+    expect(selectors(css)).toEqual(["body"]);
+  });
+
+  it("keeps a rule after a comment holding a dark opener", () => {
+    const css = "/* @media (prefers-color-scheme: dark) { */ body{color:red}";
+    expect(selectors(css)).toEqual(["body"]);
   });
 });
 
-// `disableDarkStyles` sets a module flag that lives for the whole realm and nothing resets it,
-// and jasmine runs specs in random order, so the before and after states cannot be split into
-// two specs: whichever ran second would find the flag already set. One spec walks the whole
-// lifecycle instead. Keep dark CSS out of every other spec in this file for the same reason.
+// Keep dark CSS out of every other spec in this file, and keep this lifecycle in one spec:
+// `disableDarkStyles()` sets a realm-wide flag that nothing resets, and jasmine randomizes
+// order, so a second spec would find it already set.
 describe("Core - disableDarkStyles", () => {
   it("strips dark rules from stylesheets already inserted, and from later ones", () => {
     const DARK = "@media (prefers-color-scheme: dark){.x{color:#fff}}";
@@ -207,10 +187,12 @@ describe("Core - disableDarkStyles", () => {
     expect(existing.textContent).toContain("prefers-color-scheme");
 
     disableDarkStyles();
-    expect(existing.textContent).toBe(".x{color:red}");
+    expect(existing.textContent).not.toContain("prefers-color-scheme");
+    expect(existing.textContent).toContain(".x");
 
     const later = insertStyle(`.y{color:green}${DARK}`);
-    expect(later.textContent).toBe(".y{color:green}");
+    expect(later.textContent).not.toContain("prefers-color-scheme");
+    expect(later.textContent).toContain(".y");
 
     existing.remove();
     later.remove();

--- a/tests/unit/core/insert-style-spec.js
+++ b/tests/unit/core/insert-style-spec.js
@@ -1,10 +1,6 @@
 "use strict";
 
-import {
-  disableDarkStyles,
-  insertStyle,
-  stripDarkMediaBlocks,
-} from "/src/core/insert-style.js";
+import { disableDarkStyles, insertStyle } from "/src/core/insert-style.js";
 
 describe("Core - insertStyle", () => {
   /** @type {Element[]} */
@@ -80,14 +76,38 @@ describe("Core - insertStyle", () => {
   });
 });
 
-describe("Core - stripDarkMediaBlocks", () => {
-  // Assert on the rules, not the text: the parser normalizes what it re-serializes, so a
-  // string comparison here would be testing the serializer.
+// `disableDarkStyles()` flips a realm-wide flag that nothing resets, so `beforeAll` does it
+// once for this whole block rather than a spec doing it and leaking into the others. Keep dark
+// CSS out of every spec outside this block.
+describe("Core - dark styles removed", () => {
+  /** @type {HTMLStyleElement} */
+  let insertedBefore;
+  /** @type {HTMLStyleElement[]} */
+  const added = [];
+
+  beforeAll(() => {
+    insertedBefore = insertStyle(
+      ".pre{color:red}@media (prefers-color-scheme: dark){.pre{color:#fff}}"
+    );
+    added.push(insertedBefore);
+    disableDarkStyles();
+  });
+
+  afterAll(() => {
+    for (const el of added) el.remove();
+  });
+
+  /** @param {string} css @returns {string} what landed in the document */
+  function inserted(css) {
+    const style = insertStyle(css);
+    added.push(style);
+    return style.textContent;
+  }
 
   /** @param {string} css @returns {string[]} the condition of each surviving `@media` */
   function conditions(css) {
     const sheet = new CSSStyleSheet();
-    sheet.replaceSync(stripDarkMediaBlocks(css));
+    sheet.replaceSync(inserted(css));
     return [...sheet.cssRules]
       .filter(r => r instanceof CSSMediaRule)
       .map(r => r.conditionText);
@@ -96,15 +116,20 @@ describe("Core - stripDarkMediaBlocks", () => {
   /** @param {string} css @returns {string[]} the selector of each surviving top-level rule */
   function selectors(css) {
     const sheet = new CSSStyleSheet();
-    sheet.replaceSync(stripDarkMediaBlocks(css));
+    sheet.replaceSync(inserted(css));
     return [...sheet.cssRules]
       .filter(r => r instanceof CSSStyleRule)
       .map(r => r.selectorText);
   }
 
-  it("returns CSS with no dark block unchanged", () => {
-    expect(stripDarkMediaBlocks("")).toBe("");
-    expect(selectors("body { color: black; }")).toEqual(["body"]);
+  it("rewrites stylesheets inserted before the option was read", () => {
+    expect(insertedBefore.textContent).not.toContain("prefers-color-scheme");
+    expect(insertedBefore.textContent).toContain(".pre");
+  });
+
+  it("leaves CSS with nothing to remove byte-identical", () => {
+    const css = 'a[data-x="1"] > b::after{content:"&"}';
+    expect(inserted(css)).toBe(css);
   });
 
   it("removes a dark block and keeps everything else", () => {
@@ -115,40 +140,42 @@ describe("Core - stripDarkMediaBlocks", () => {
   });
 
   it("leaves other media queries alone", () => {
-    expect(conditions("@media print { body { color: black; } }")).toEqual([
-      "print",
-    ]);
+    expect(conditions("@media print{body{color:black}}")).toEqual(["print"]);
     expect(
-      conditions("@media (prefers-color-scheme: light) { a{color:red} }")
+      conditions("@media (prefers-color-scheme: light){a{color:red}}")
     ).toEqual(["(prefers-color-scheme: light)"]);
   });
 
   it("handles minified CSS, where the whole sheet is one line", () => {
-    const css =
-      "a{color:red}@media(prefers-color-scheme:dark){b{color:#fff}}c{color:blue}";
-    expect(selectors(css)).toEqual(["a", "c"]);
+    expect(
+      selectors(
+        "a{color:red}@media(prefers-color-scheme:dark){b{color:#fff}}c{color:blue}"
+      )
+    ).toEqual(["a", "c"]);
   });
 
   it("removes a nested dark block whole, braces and all", () => {
-    const css =
-      "@media (prefers-color-scheme: dark) { @supports (display: grid) { a{color:red} } }";
-    expect(stripDarkMediaBlocks(css)).toBe("");
+    expect(
+      inserted(
+        "@media (prefers-color-scheme: dark){@supports (display:grid){a{color:red}}}"
+      )
+    ).toBe("");
   });
 
   it("removes every dark block, not just the first", () => {
-    const css =
-      "@media (prefers-color-scheme: dark){a{color:red}} @media (prefers-color-scheme: dark){b{color:blue}}";
-    expect(conditions(css)).toEqual([]);
+    expect(
+      conditions(
+        "@media (prefers-color-scheme: dark){a{color:red}} @media (prefers-color-scheme: dark){b{color:blue}}"
+      )
+    ).toEqual([]);
   });
 
   it("removes a dark condition combined with others", () => {
     expect(
-      conditions(
-        "@media screen and (prefers-color-scheme: dark) { a{color:red} }"
-      )
+      conditions("@media screen and (prefers-color-scheme: dark){a{color:red}}")
     ).toEqual([]);
     expect(
-      conditions("@media print, (prefers-color-scheme: dark) { a{color:red} }")
+      conditions("@media print,(prefers-color-scheme: dark){a{color:red}}")
     ).toEqual([]);
   });
 
@@ -161,40 +188,22 @@ describe("Core - stripDarkMediaBlocks", () => {
   });
 
   it("keeps a rule holding a brace in a string", () => {
-    const css =
-      "@media (prefers-color-scheme: dark){a::after{content:'}'}}c{color:blue}";
-    expect(selectors(css)).toEqual(["c"]);
+    expect(
+      selectors(
+        "@media (prefers-color-scheme: dark){a::after{content:'}'}}c{color:blue}"
+      )
+    ).toEqual(["c"]);
   });
 
   it("keeps a rule whose declaration merely mentions a dark at-rule", () => {
-    const css = "body { content: '@media (prefers-color-scheme: dark) {}'; }";
-    expect(selectors(css)).toEqual(["body"]);
+    expect(
+      selectors("body{content:'@media (prefers-color-scheme: dark) {}'}")
+    ).toEqual(["body"]);
   });
 
   it("keeps a rule after a comment holding a dark opener", () => {
-    const css = "/* @media (prefers-color-scheme: dark) { */ body{color:red}";
-    expect(selectors(css)).toEqual(["body"]);
-  });
-});
-
-// Keep dark CSS out of every other spec in this file, and keep this lifecycle in one spec:
-// `disableDarkStyles()` sets a realm-wide flag that nothing resets, and jasmine randomizes
-// order, so a second spec would find it already set.
-describe("Core - disableDarkStyles", () => {
-  it("strips dark rules from stylesheets already inserted, and from later ones", () => {
-    const DARK = "@media (prefers-color-scheme: dark){.x{color:#fff}}";
-    const existing = insertStyle(`.x{color:red}${DARK}`);
-    expect(existing.textContent).toContain("prefers-color-scheme");
-
-    disableDarkStyles();
-    expect(existing.textContent).not.toContain("prefers-color-scheme");
-    expect(existing.textContent).toContain(".x");
-
-    const later = insertStyle(`.y{color:green}${DARK}`);
-    expect(later.textContent).not.toContain("prefers-color-scheme");
-    expect(later.textContent).toContain(".y");
-
-    existing.remove();
-    later.remove();
+    expect(
+      selectors("/* @media (prefers-color-scheme: dark) { */ body{color:red}")
+    ).toEqual(["body"]);
   });
 });


### PR DESCRIPTION
An editor can now set `darkMode: false` and ReSpec stops offering dark mode for that spec: it emits no dark stylesheet, so W3C's fixup.js finds nothing to toggle, and it removes its own `@media (prefers-color-scheme: dark)` blocks so a reader whose operating system prefers dark does not land on a light page with dark ReSpec components in it. This matches Bikeshed's `Dark Mode` metadata, including that second half. Only an explicit `false` disables anything.

The option is transitional and the documentation says so: custom CSS that is not dark-aware is the thing to fix.

Removing those blocks goes through the browser's own CSS parser, `CSSStyleSheet.replaceSync`, rather than scanning for braces. A hand-rolled scanner got four inputs wrong, each of which silently deleted valid CSS: an unterminated block, a dark `@media` opener inside a comment, a brace inside a string, and `not (prefers-color-scheme: dark)`, which is the one construct that forces a page light. The parser handles all four. Two consequences: a stylesheet that has something removed comes back re-serialized, so its formatting is normalized and comments are gone, and one with nothing to remove is returned untouched.

Nothing reaches the author's own CSS. The strip only visits stylesheets that went through `core/insert-style`, which sees only strings ReSpec passed it.

Gemini reviewed the module and its tests and found the unterminated-block case, plus that `disableDarkStyles` had no test at all. Both are fixed here.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.

<!-- ai-proof:start -->

Proof: `BROWSERS=ChromeHeadless npx karma start tests/unit/karma.conf.cjs --single-run` covers the strip through the public API, 87 specs. Each guard is mutation-proven rather than merely green: neutering the `not` check fails "keeps `not (prefers-color-scheme: dark)`, which forces a page light", and making the strip a no-op fails six specs including the `disableDarkStyles` lifecycle. The suite was run five times to confirm it is stable under jasmine's random ordering, because `disableDarkStyles` sets a realm-wide flag that nothing resets.
<!-- ai-proof:
{
  "mode": "mutation",
  "base": "9e7d29ea",
  "head": "6732a2a5",
  "repro": "BROWSERS=ChromeHeadless npx karma start tests/unit/karma.conf.cjs --single-run",
  "before": "failed",
  "after": "passed",
  "blocker": "the option does not exist on the base commit, so base-sha cannot exercise it; each guard is instead proven by mutating it on the head commit and naming the spec that fails"
}
-->
<!-- ai-proof:end -->
