### PR TITLE
fix(core/biblio): fall back to respec.org when Specref is unreachable

### DIFF
--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -12,17 +12,13 @@ export const biblio = {};
 
 export const name = "core/biblio";
 
-/**
- * Specref first, then respec.org's mirror of the same data. Keeping Specref
- * primary means a citation resolves identically here and in other spec tools,
- * and that ReSpec goes back to it on its own once it answers again.
- */
+/** Keep Specref first: a citation then resolves the same here as in every other spec tool. */
 const bibrefsURLs = [
   new URL("https://api.specref.org/bibrefs?refs="),
   new URL("https://respec.org/bibrefs?refs="),
 ];
 
-/** Bounds the wait when the first service accepts a connection and never replies. */
+/** Without this, a service that connects and never replies blocks the fallback. */
 const FETCH_TIMEOUT_MS = 5000;
 
 // Opportunistically dns-prefetch to bibref server, as we don't know yet
@@ -41,11 +37,14 @@ const done = new Promise(resolve => {
 });
 
 /**
+ * Asks each bibliography service in turn and returns the first usable answer.
+ * A service only counts as answering once its body parses, so an error page
+ * that comes back as 200 and HTML still falls through to the next one.
+ *
  * @param {string} refs comma separated reference ids
- * @param {{ forceUpdate: boolean }} options
- * @returns {Promise<Response | null>} the first service that answered, if any
+ * @returns {Promise<{ data: Conf['biblio'], expires: string | null } | null>}
  */
-async function fetchBibrefs(refs, options) {
+async function fetchBibrefs(refs) {
   for (const url of bibrefsURLs) {
     let response;
     try {
@@ -56,36 +55,37 @@ async function fetchBibrefs(refs, options) {
       console.warn(`Could not reach ${url.origin} for references.`, err);
       continue;
     }
-    if ((!options.forceUpdate && !response.ok) || response.status !== 200) {
+    if (response.status !== 200) {
       console.warn(`${url.origin} answered ${response.status} for references.`);
       continue;
     }
-    return response;
+    try {
+      const data = await response.json();
+      return { data, expires: response.headers.get("Expires") };
+    } catch (err) {
+      console.warn(`${url.origin} sent references that are not JSON.`, err);
+    }
   }
   return null;
 }
 
 /** @param {string[]} refs */
-export async function updateFromNetwork(
-  refs,
-  options = { forceUpdate: false }
-) {
+export async function updateFromNetwork(refs) {
   const refsToFetch = [...new Set(refs)].filter(ref => ref.trim());
   // Update database if needed, if we are online
   if (!refsToFetch.length || navigator.onLine === false) {
     return null;
   }
-  const response = await fetchBibrefs(refsToFetch.join(","), options);
-  if (!response) {
+  const found = await fetchBibrefs(refsToFetch.join(","));
+  if (!found) {
     return null;
   }
-  /** @type {Conf['biblio']} */
-  const data = await response.json();
+  const { data, expires: expiresHeader } = found;
   // SpecRef updates every hour, so we should follow suit
   // https://github.com/tobie/specref#hourly-auto-updating
   const oneHourFromNow = Date.now() + 1000 * 60 * 60 * 1;
   try {
-    const expiresValue = Date.parse(response.headers.get("Expires") || "");
+    const expiresValue = Date.parse(expiresHeader || "");
     const expires = Number.isNaN(expiresValue)
       ? oneHourFromNow
       : Math.min(expiresValue, oneHourFromNow);
@@ -203,7 +203,7 @@ export class Plugin {
     const externalRefs = split.noData.map(item => item.id);
     if (externalRefs.length) {
       // Going to the network for refs we don't have
-      const data = await updateFromNetwork(externalRefs, { forceUpdate: true });
+      const data = await updateFromNetwork(externalRefs);
       Object.assign(biblio, data);
     }
     Object.assign(biblio, this.conf.localBiblio);

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -12,13 +12,24 @@ export const biblio = {};
 
 export const name = "core/biblio";
 
-const bibrefsURL = new URL("https://api.specref.org/bibrefs?refs=");
+/**
+ * Specref first, then respec.org's mirror of the same data. Keeping Specref
+ * primary means a citation resolves identically here and in other spec tools,
+ * and that ReSpec goes back to it on its own once it answers again.
+ */
+const bibrefsURLs = [
+  new URL("https://api.specref.org/bibrefs?refs="),
+  new URL("https://respec.org/bibrefs?refs="),
+];
+
+/** Bounds the wait when the first service accepts a connection and never replies. */
+const FETCH_TIMEOUT_MS = 5000;
 
 // Opportunistically dns-prefetch to bibref server, as we don't know yet
 // if we will actually need to download references yet.
 const link = createResourceHint({
   hint: "dns-prefetch",
-  href: bibrefsURL.origin,
+  href: bibrefsURLs[0].origin,
 });
 document.head.appendChild(link);
 /** @type {(value: Conf['biblio']) => void} */
@@ -28,6 +39,31 @@ let doneResolver;
 const done = new Promise(resolve => {
   doneResolver = resolve;
 });
+
+/**
+ * @param {string} refs comma separated reference ids
+ * @param {{ forceUpdate: boolean }} options
+ * @returns {Promise<Response | null>} the first service that answered, if any
+ */
+async function fetchBibrefs(refs, options) {
+  for (const url of bibrefsURLs) {
+    let response;
+    try {
+      response = await fetch(url.href + refs, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch (err) {
+      console.warn(`Could not reach ${url.origin} for references.`, err);
+      continue;
+    }
+    if ((!options.forceUpdate && !response.ok) || response.status !== 200) {
+      console.warn(`${url.origin} answered ${response.status} for references.`);
+      continue;
+    }
+    return response;
+  }
+  return null;
+}
 
 /** @param {string[]} refs */
 export async function updateFromNetwork(
@@ -39,14 +75,8 @@ export async function updateFromNetwork(
   if (!refsToFetch.length || navigator.onLine === false) {
     return null;
   }
-  let response;
-  try {
-    response = await fetch(bibrefsURL.href + refsToFetch.join(","));
-  } catch (err) {
-    console.error(err);
-    return null;
-  }
-  if ((!options.forceUpdate && !response.ok) || response.status !== 200) {
+  const response = await fetchBibrefs(refsToFetch.join(","), options);
+  if (!response) {
     return null;
   }
   /** @type {Conf['biblio']} */

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -74,10 +74,16 @@ describe("W3C — Bibliographic References", () => {
   let doc;
   let bibrefsOk;
   beforeAll(async () => {
+    // Clear first, or the check below passes on a DOM entry another spec left
+    // in IndexedDB and proves nothing about either service.
+    const { biblioDB } = await import("../../../src/core/biblio-db.js");
+    await biblioDB.ready;
+    await biblioDB.clear();
+
     doc = await makeRSDoc(ops);
-    // Whether a reference only the bibliography service can resolve came back.
-    // A fetch from here would not do: the suite redirects service requests with
-    // a service worker scoped to the spec document, not to this context.
+    // DOM is the one reference here that only a service can resolve. Reading it
+    // off the page rather than fetching it is deliberate: the suite's redirect
+    // to a local service is a service worker scoped to the spec document.
     bibrefsOk = Boolean(doc.querySelector("#bib-dom + dd cite"));
   });
 

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -71,13 +71,14 @@ describe("W3C — Bibliographic References", () => {
   const ops = makeStandardOps({ localBiblio }, body);
 
   afterAll(flushIframes);
-  const bibRefsURL = new URL("https://api.specref.org/bibrefs");
-
   let doc;
-  let specRefOk;
+  let bibrefsOk;
   beforeAll(async () => {
     doc = await makeRSDoc(ops);
-    specRefOk = (await fetch(bibRefsURL, { method: "HEAD" })).ok;
+    // Whether a reference only the bibliography service can resolve came back.
+    // A fetch from here would not do: the suite redirects service requests with
+    // a service worker scoped to the spec document, not to this context.
+    bibrefsOk = Boolean(doc.querySelector("#bib-dom + dd cite"));
   });
 
   it("displays references correctly", async () => {
@@ -93,7 +94,7 @@ describe("W3C — Bibliographic References", () => {
   });
 
   it("pings biblio service to see if it's running", () => {
-    expect(specRefOk).toBeTruthy();
+    expect(bibrefsOk).toBeTruthy();
   });
 
   it("includes the title of a spec for an inline citation, including aliases", async () => {
@@ -121,7 +122,7 @@ describe("W3C — Bibliographic References", () => {
   });
 
   it("includes a dns-prefetch to bibref server", () => {
-    const host = bibRefsURL.host;
+    const host = "api.specref.org";
     const link = doc.querySelector(`link[rel='dns-prefetch'][href*='${host}']`);
     expect(link).toBeTruthy();
     expect(link.classList).toContain("removeOnSave");
@@ -131,10 +132,11 @@ describe("W3C — Bibliographic References", () => {
     // Make sure the reference is added.
     let ref = doc.querySelector("#bib-testref1 + dd");
     expect(ref).toBeTruthy();
-    // This prevents Jasmine from taking down the whole test suite if SpecRef is down.
-    if (!specRefOk) {
+    // This prevents Jasmine from taking down the whole test suite if the
+    // bibliography service is down.
+    if (!bibrefsOk) {
       throw new Error(
-        "SpecRef seems to be down. Can't proceed with this spec."
+        "The bibliography service seems to be down. Can't proceed with this spec."
       );
     }
     expect(ref.textContent).toMatch(/Publishers Inc\.\s/);

--- a/tests/unit/core/biblio-services-spec.js
+++ b/tests/unit/core/biblio-services-spec.js
@@ -1,0 +1,76 @@
+"use strict";
+
+import { updateFromNetwork } from "/src/core/biblio.js";
+
+const SPECREF = "https://api.specref.org/bibrefs";
+const MIRROR = "https://respec.org/bibrefs";
+
+const ENTRY = {
+  TESTREF: { id: "TESTREF", title: "Test", href: "https://e.com/" },
+};
+
+describe("Core - biblio bibliography services", () => {
+  let realFetch;
+  let attempted;
+
+  beforeEach(() => {
+    realFetch = window.fetch;
+    attempted = [];
+  });
+
+  afterEach(() => {
+    window.fetch = realFetch;
+  });
+
+  /** @param {(url: string) => Response | Error} answer */
+  function stubFetch(answer) {
+    window.fetch = url => {
+      attempted.push(String(url).split("?")[0]);
+      const result = answer(String(url));
+      return result instanceof Error
+        ? Promise.reject(result)
+        : Promise.resolve(result);
+    };
+  }
+
+  function jsonResponse(body) {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("asks Specref first and does not ask the mirror when it answers", async () => {
+    stubFetch(() => jsonResponse(ENTRY));
+    const data = await updateFromNetwork(["TESTREF"], { forceUpdate: true });
+    expect(data).toEqual(ENTRY);
+    expect(attempted).toEqual([SPECREF]);
+  });
+
+  it("falls back to the mirror when Specref cannot be reached", async () => {
+    stubFetch(url =>
+      url.startsWith(SPECREF) ? new Error("network") : jsonResponse(ENTRY)
+    );
+    const data = await updateFromNetwork(["TESTREF"], { forceUpdate: true });
+    expect(data).toEqual(ENTRY);
+    expect(attempted).toEqual([SPECREF, MIRROR]);
+  });
+
+  it("falls back to the mirror when Specref answers with an error status", async () => {
+    stubFetch(url =>
+      url.startsWith(SPECREF)
+        ? new Response("nope", { status: 503 })
+        : jsonResponse(ENTRY)
+    );
+    const data = await updateFromNetwork(["TESTREF"], { forceUpdate: true });
+    expect(data).toEqual(ENTRY);
+    expect(attempted).toEqual([SPECREF, MIRROR]);
+  });
+
+  it("gives up when neither service answers", async () => {
+    stubFetch(() => new Error("network"));
+    const data = await updateFromNetwork(["TESTREF"], { forceUpdate: true });
+    expect(data).toBeNull();
+    expect(attempted).toEqual([SPECREF, MIRROR]);
+  });
+});

--- a/tests/unit/core/biblio-services-spec.js
+++ b/tests/unit/core/biblio-services-spec.js
@@ -42,7 +42,7 @@ describe("Core - biblio bibliography services", () => {
 
   it("asks Specref first and does not ask the mirror when it answers", async () => {
     stubFetch(() => jsonResponse(ENTRY));
-    const data = await updateFromNetwork(["TESTREF"], { forceUpdate: true });
+    const data = await updateFromNetwork(["TESTREF"]);
     expect(data).toEqual(ENTRY);
     expect(attempted).toEqual([SPECREF]);
   });
@@ -51,7 +51,7 @@ describe("Core - biblio bibliography services", () => {
     stubFetch(url =>
       url.startsWith(SPECREF) ? new Error("network") : jsonResponse(ENTRY)
     );
-    const data = await updateFromNetwork(["TESTREF"], { forceUpdate: true });
+    const data = await updateFromNetwork(["TESTREF"]);
     expect(data).toEqual(ENTRY);
     expect(attempted).toEqual([SPECREF, MIRROR]);
   });
@@ -62,14 +62,28 @@ describe("Core - biblio bibliography services", () => {
         ? new Response("nope", { status: 503 })
         : jsonResponse(ENTRY)
     );
-    const data = await updateFromNetwork(["TESTREF"], { forceUpdate: true });
+    const data = await updateFromNetwork(["TESTREF"]);
+    expect(data).toEqual(ENTRY);
+    expect(attempted).toEqual([SPECREF, MIRROR]);
+  });
+
+  it("falls back to the mirror when Specref answers 200 with something other than JSON", async () => {
+    stubFetch(url =>
+      url.startsWith(SPECREF)
+        ? new Response("<html>Gateway</html>", {
+            status: 200,
+            headers: { "Content-Type": "text/html" },
+          })
+        : jsonResponse(ENTRY)
+    );
+    const data = await updateFromNetwork(["TESTREF"]);
     expect(data).toEqual(ENTRY);
     expect(attempted).toEqual([SPECREF, MIRROR]);
   });
 
   it("gives up when neither service answers", async () => {
     stubFetch(() => new Error("network"));
-    const data = await updateFromNetwork(["TESTREF"], { forceUpdate: true });
+    const data = await updateFromNetwork(["TESTREF"]);
     expect(data).toBeNull();
     expect(attempted).toEqual([SPECREF, MIRROR]);
   });


### PR DESCRIPTION
Specref has been offline since 30 August, so references stop resolving. core/biblio now tries it first and falls back to respec.org/bibrefs, so the liveness spec fails until that endpoint is deployed.

Written with Claude: the fallback and its tests are generated logic.
