### PR TITLE
test: warn when SPECREF_BASE alone leaves bibliography on production

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,8 @@ BROWSERS=ChromeHeadless npx karma start tests/spec/karma.conf.cjs --single-run
 
 Set neither and everything goes to production exactly as before. A service worker (`tests/spec/respec-test-sw.js`) does the redirecting, so it also covers requests no per-document `fetch` wrapper reaches, such as the highlighter's `importScripts`.
 
+**Set both, or bibliography still reaches production.** `core/biblio.js` asks `api.specref.org` first and falls back to `respec.org/bibrefs`, and these variables replace whole origins, so `SPECREF_BASE` alone leaves that fallback on the network: a local Specref that is stopped or broken still passes the bibliography specs, quietly answered by production. Karma warns when only one is set.
+
 Two consequences to expect. While either variable is set the suite stops seeding the Cache API and gives each spec document a cache that misses every lookup, so every request really reaches your service rather than being answered from a fixture. And a service that is not running answers 502 through the worker, which surfaces as ReSpec's ordinary "response was not ok" handling rather than as an unhandled rejection.
 
 ## Code style

--- a/tests/karma.conf.base.cjs
+++ b/tests/karma.conf.base.cjs
@@ -99,6 +99,17 @@ module.exports = config => {
     },
   };
 
+  // Set both or bibliography goes untested: core/biblio.js falls back to
+  // respec.org/bibrefs, and an origin rewrite cannot separate that from xref.
+  if (process.env.SPECREF_BASE && !process.env.RESPEC_SERVICES_BASE) {
+    process.emitWarning(
+      "SPECREF_BASE is set but RESPEC_SERVICES_BASE is not. Bibliography falls back " +
+        "to respec.org/bibrefs, so those requests still go to production. Set both to " +
+        "test bibliography against a local service.",
+      "ReSpecServiceOrigins"
+    );
+  }
+
   if (process.env.BROWSERS) {
     options.browsers = process.env.BROWSERS.split(" ");
   }


### PR DESCRIPTION
Follow-up to #5445. core/biblio.js now falls back from api.specref.org to respec.org/bibrefs, and the test override replaces whole origins, so SPECREF_BASE alone cannot redirect that fallback: a stopped local Specref still passes all 17 bibliography specs because production answered them. Karma now warns in that one configuration.

Written with Claude.
