### PR TITLE
test: warn in both directions when only one service origin is set

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,7 +52,7 @@ BROWSERS=ChromeHeadless npx karma start tests/spec/karma.conf.cjs --single-run
 
 Set neither and everything goes to production exactly as before. A service worker (`tests/spec/respec-test-sw.js`) does the redirecting, so it also covers requests no per-document `fetch` wrapper reaches, such as the highlighter's `importScripts`.
 
-**Set both, or bibliography still reaches production.** `core/biblio.js` asks `api.specref.org` first and falls back to `respec.org/bibrefs`, and these variables replace whole origins, so `SPECREF_BASE` alone leaves that fallback on the network: a local Specref that is stopped or broken still passes the bibliography specs, quietly answered by production. Karma warns when only one is set.
+**Set both, or bibliography can still reach production.** `core/biblio.js` asks `api.specref.org` first and can fall back to `respec.org/bibrefs`, and these variables replace whole origins, so either one on its own leaves one of those two on the network: with only `SPECREF_BASE`, the fallback goes to production, and with only `RESPEC_SERVICES_BASE`, the first attempt does. Either way a local Specref that is stopped or broken can still pass the bibliography specs, quietly answered by production. Karma warns when only one is set.
 
 Two consequences to expect. While either variable is set the suite stops seeding the Cache API and gives each spec document a cache that misses every lookup, so every request really reaches your service rather than being answered from a fixture. And a service that is not running answers 502 through the worker, which surfaces as ReSpec's ordinary "response was not ok" handling rather than as an unhandled rejection.
 

--- a/tests/karma.conf.base.cjs
+++ b/tests/karma.conf.base.cjs
@@ -99,13 +99,19 @@ module.exports = config => {
     },
   };
 
-  // Set both or bibliography goes untested: core/biblio.js falls back to
-  // respec.org/bibrefs, and an origin rewrite cannot separate that from xref.
-  if (process.env.SPECREF_BASE && !process.env.RESPEC_SERVICES_BASE) {
+  // Set both or bibliography goes untested whichever one you set: core/biblio.js tries
+  // api.specref.org then respec.org/bibrefs, and an origin rewrite cannot separate that
+  // second one from xref.
+  const [specref, services] = [
+    process.env.SPECREF_BASE,
+    process.env.RESPEC_SERVICES_BASE,
+  ];
+  if (Boolean(specref) !== Boolean(services)) {
+    const unset = specref ? "RESPEC_SERVICES_BASE" : "SPECREF_BASE";
+    const reached = specref ? "respec.org/bibrefs" : "api.specref.org";
     process.emitWarning(
-      "SPECREF_BASE is set but RESPEC_SERVICES_BASE is not. Bibliography falls back " +
-        "to respec.org/bibrefs, so those requests still go to production. Set both to " +
-        "test bibliography against a local service.",
+      `${unset} is not set, so bibliography can still reach ${reached} on production. ` +
+        "Set both to test bibliography against a local service.",
       "ReSpecServiceOrigins"
     );
   }


### PR DESCRIPTION
Copilot's two findings on #5450. The warning covered only SPECREF_BASE, but setting only RESPEC_SERVICES_BASE leaves bibliography's first attempt on api.specref.org, which is the same false green, so it now fires for either variable and names the one that is missing. The doc line claimed both directions while the code covered one.

Written with Claude.
