### PR TITLE
fix(core/biblio): give the bibliography fallback room inside a spec budget

### DIFF
--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -18,8 +18,14 @@ const bibrefsURLs = [
   new URL("https://respec.org/bibrefs?refs="),
 ];
 
-/** Without this, a service that connects and never replies blocks the fallback. */
-const FETCH_TIMEOUT_MS = 5000;
+/**
+ * Without this, a service that connects and never replies blocks the fallback.
+ *
+ * Keep it well under the suite's per-spec budget, which jasmine defaults to 5000ms: at 5000
+ * the fallback started at the same instant a spec gave up, so a slow Specref failed the spec
+ * that the second service existed to rescue.
+ */
+const FETCH_TIMEOUT_MS = 2000;
 
 // Opportunistically dns-prefetch to bibref server, as we don't know yet
 // if we will actually need to download references yet.

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -21,9 +21,8 @@ const bibrefsURLs = [
 /**
  * Without this, a service that connects and never replies blocks the fallback.
  *
- * Keep it well under the suite's per-spec budget, which jasmine defaults to 5000ms: at 5000
- * the fallback started at the same instant a spec gave up, so a slow Specref failed the spec
- * that the second service existed to rescue.
+ * Both services share whatever time the caller allows, so keep this short enough that the
+ * second one still gets a turn.
  */
 const FETCH_TIMEOUT_MS = 2000;
 

--- a/tests/unit/core/biblio-services-spec.js
+++ b/tests/unit/core/biblio-services-spec.js
@@ -87,4 +87,33 @@ describe("Core - biblio bibliography services", () => {
     expect(data).toBeNull();
     expect(attempted).toEqual([SPECREF, MIRROR]);
   });
+
+  // A Specref that connects and never replies is the case the mirror exists for, and the
+  // whole exchange has to finish inside one spec's budget or the rescue is worthless. This
+  // spec sets its own budget rather than reading jasmine's, so raising the module's timeout
+  // back to the default fails here instead of failing whichever spec happened to be slow.
+  it("reaches the mirror well inside a spec budget when Specref hangs", async () => {
+    const BUDGET_MS = 3000;
+    window.fetch = (url, { signal } = {}) => {
+      attempted.push(String(url).split("?")[0]);
+      if (!String(url).startsWith(SPECREF)) {
+        return Promise.resolve(jsonResponse(ENTRY));
+      }
+      // Connects and never replies, but honors the abort the module arms it with. Ignoring
+      // the signal here would hang past any budget and say nothing about the timeout.
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason));
+      });
+    };
+    const started = performance.now();
+    const data = await Promise.race([
+      updateFromNetwork(["TESTREF"]),
+      new Promise(resolve =>
+        setTimeout(() => resolve("over budget"), BUDGET_MS)
+      ),
+    ]);
+    expect(performance.now() - started).toBeLessThan(BUDGET_MS);
+    expect(data).toEqual(ENTRY);
+    expect(attempted).toEqual([SPECREF, MIRROR]);
+  });
 });

--- a/tests/unit/core/biblio-services-spec.js
+++ b/tests/unit/core/biblio-services-spec.js
@@ -94,6 +94,8 @@ describe("Core - biblio bibliography services", () => {
   // back to the default fails here instead of failing whichever spec happened to be slow.
   it("reaches the mirror well inside a spec budget when Specref hangs", async () => {
     const BUDGET_MS = 3000;
+    /** Rejects the hanging request, standing in for its abort. */
+    let giveUpOnSpecref;
     window.fetch = (url, { signal } = {}) => {
       attempted.push(String(url).split("?")[0]);
       if (!String(url).startsWith(SPECREF)) {
@@ -102,17 +104,29 @@ describe("Core - biblio bibliography services", () => {
       // Connects and never replies, but honors the abort the module arms it with. Ignoring
       // the signal here would hang past any budget and say nothing about the timeout.
       return new Promise((_resolve, reject) => {
+        giveUpOnSpecref = () => reject(new Error("hanging request abandoned"));
         signal?.addEventListener("abort", () => reject(signal.reason));
       });
     };
+
+    const update = updateFromNetwork(["TESTREF"]);
     const started = performance.now();
-    const data = await Promise.race([
-      updateFromNetwork(["TESTREF"]),
+    await Promise.race([
+      update,
       new Promise(resolve =>
-        setTimeout(() => resolve("over budget"), BUDGET_MS)
+        setTimeout(() => {
+          // Over budget means the module is still waiting on Specref. Cut it loose so the
+          // fallback runs against this stub: leaving it pending would let the real `fetch`,
+          // restored in `afterEach`, serve the mirror from the network mid-suite.
+          giveUpOnSpecref?.();
+          resolve();
+        }, BUDGET_MS)
       ),
     ]);
-    expect(performance.now() - started).toBeLessThan(BUDGET_MS);
+    const elapsed = performance.now() - started;
+    const data = await update;
+
+    expect(elapsed).toBeLessThan(BUDGET_MS);
     expect(data).toEqual(ENTRY);
     expect(attempted).toEqual([SPECREF, MIRROR]);
   });

--- a/tests/unit/core/biblio-services-spec.js
+++ b/tests/unit/core/biblio-services-spec.js
@@ -88,10 +88,6 @@ describe("Core - biblio bibliography services", () => {
     expect(attempted).toEqual([SPECREF, MIRROR]);
   });
 
-  // A Specref that connects and never replies is the case the mirror exists for, and the
-  // whole exchange has to finish inside one spec's budget or the rescue is worthless. This
-  // spec sets its own budget rather than reading jasmine's, so raising the module's timeout
-  // back to the default fails here instead of failing whichever spec happened to be slow.
   it("reaches the mirror well inside a spec budget when Specref hangs", async () => {
     const BUDGET_MS = 3000;
     /** Rejects the hanging request, standing in for its abort. */
@@ -101,8 +97,6 @@ describe("Core - biblio bibliography services", () => {
       if (!String(url).startsWith(SPECREF)) {
         return Promise.resolve(jsonResponse(ENTRY));
       }
-      // Connects and never replies, but honors the abort the module arms it with. Ignoring
-      // the signal here would hang past any budget and say nothing about the timeout.
       return new Promise((_resolve, reject) => {
         giveUpOnSpecref = () => reject(new Error("hanging request abandoned"));
         signal?.addEventListener("abort", () => reject(signal.reason));
@@ -115,9 +109,8 @@ describe("Core - biblio bibliography services", () => {
       update,
       new Promise(resolve =>
         setTimeout(() => {
-          // Over budget means the module is still waiting on Specref. Cut it loose so the
-          // fallback runs against this stub: leaving it pending would let the real `fetch`,
-          // restored in `afterEach`, serve the mirror from the network mid-suite.
+          // Cut the hanging request loose so the fallback runs against this stub. Left
+          // pending, it outlives `afterEach` and serves the mirror from the real network.
           giveUpOnSpecref?.();
           resolve();
         }, BUDGET_MS)


### PR DESCRIPTION
`core/biblio.js` asks Specref first and falls back to `respec.org/bibrefs`, with a 5000ms timeout per service. That is exactly jasmine's default per-spec budget, so when Specref is reachable but slow rather than down, the fallback starts at the same instant the spec gives up and the second service cannot help. This drops the timeout to 2000ms, which leaves the fallback room to land inside the budget.

The new spec pins that: Specref connects and never replies, and the mirror still answers within 3000ms. It passes at 2.003s, and restoring 5000 fails it at 3.004s, so the value cannot drift back unnoticed.

Written with AI: this change was generated by Claude. Per AI_POLICY.md.

<!-- ai-proof:start -->

Proof: `BROWSERS=ChromeHeadless npx karma start tests/unit/karma.conf.cjs --single-run --grep="biblio bibliography services"` passes 6 specs on the head commit. Setting `FETCH_TIMEOUT_MS` back to 5000 fails "reaches the mirror well inside a spec budget when Specref hangs" with a 3.004s timeout, so the assertion is load-bearing rather than merely green.
<!-- ai-proof:
{
  "mode": "mutation",
  "base": "9e7d29ea",
  "head": "f0033b08",
  "repro": "BROWSERS=ChromeHeadless npx karma start tests/unit/karma.conf.cjs --single-run --grep=\"biblio bibliography services\"",
  "before": "failed",
  "after": "passed",
  "blocker": "the spec does not exist on the base commit, so base-sha cannot run it; the guard is proven by restoring 5000 on the head commit and naming the spec that fails"
}
-->
<!-- ai-proof:end -->
