### PR TITLE
fix(w3c): Correct capitalization of working group

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -262,7 +262,7 @@ function renderNotRec(conf) {
         <a href="${processLink}#dfn-wide-review">wide review</a>, is intended to
         gather
         <a href="${conf.implementationReportURI}">implementation experience</a>,
-        and has commitments from Working Group members to
+        and has commitments from working group members to
         <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements"
           >royalty-free licensing</a
         >
@@ -335,7 +335,7 @@ function renderIsRec(conf) {
       A W3C Recommendation is a specification that, after extensive
       consensus-building, is endorsed by
       <abbr title="World Wide Web Consortium">W3C</abbr> and its Members, and
-      has commitments from Working Group members to
+      has commitments from working group members to
       <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements"
         >royalty-free licensing</a
       >


### PR DESCRIPTION
Following W3C style, only capitalize when it is part of a proper name, and not when it is in the plural form.

See: https://w3c.github.io/style-guide/#capitalization